### PR TITLE
Make sure we build static libs with -fPIC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,17 @@ LDFLAGS+="-L/usr/local/lib "
 fi
 CFLAGS+=" -DKL_USERSPACE "
 
+# We always build with -fPIC in case our static libraries end up
+# being linked into a consumer's shared library
+AC_MSG_CHECKING(whether fPIC compiler option is accepted)
+SAVED_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -fPIC -Werror"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [return 0;])],
+    [AC_MSG_RESULT(yes)
+     CFLAGS="$SAVED_CFLAGS -fPIC"],
+    [AC_MSG_RESULT(no)
+     CFLAGS="$SAVED_CFLAGS"])
+
 AC_PROG_RANLIB
 AC_PROG_LIBTOOL
 


### PR DESCRIPTION
We need to make sure the static libs are built with -fPIC, and not
just the shared libraries.  This is because there are cases where our
static library gets built into a shared library (such as a VLC loadable
module), and -fPIC is required for those cases.