### PR TITLE
104 refactoring

### DIFF
--- a/src/smpte2038.c
+++ b/src/smpte2038.c
@@ -203,6 +203,11 @@ int smpte2038_parse_pes_packet(uint8_t *section, unsigned int byteCount, struct 
 
 	*result = h;
 	ret = 0;
+
+	if (bs)
+		klbs_free(bs);
+	return ret;
+
 err:
 	if (h)
 		free(h);


### PR DESCRIPTION
A regression during the SCA cleanup causes VLC to crash as soon as there is an SMPTE 2038 packet to parse.  Please apply.