### PR TITLE
Zero out memory when allocating new ops.

### DIFF
--- a/src/core-packet-scte_104.c
+++ b/src/core-packet-scte_104.c
@@ -1069,6 +1069,7 @@ int klvanc_SCTE_104_Add_MOM_Op(struct packet_scte_104_s *pkt, uint16_t opId,
 	mom->ops = realloc(mom->ops,
 			   mom->num_ops * sizeof(struct multiple_operation_message_operation));
 	*op = &mom->ops[mom->num_ops - 1];
+	memset(*op, 0, sizeof(struct multiple_operation_message_operation));
 	(*op)->opID = opId;
 
 	return 0;


### PR DESCRIPTION
The data_length struct member was uninitialized, which resulted
in an intermittent crash when calling dump_mom().  For the sake of
safety, memset() the entire structure prior to use.