### PR TITLE
Setup a logger object rather than just calling printf()/fprintf()

### DIFF
--- a/src/core-packet-afd.c
+++ b/src/core-packet-afd.c
@@ -120,17 +120,16 @@ const char *klvanc_aspectRatio_to_string(enum klvanc_payload_aspect_ratio_e ar)
 int klvanc_dump_AFD(struct klvanc_context_s *ctx, void *p)
 {
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_afd_s *pkt = p;
 
-	printf("%s() AFD: %s Aspect Ratio: %s Flags: 0x%x Value1: 0x%x Value2: 0x%x\n", __func__,
-		klvanc_afd_to_string(pkt->afd),
-		klvanc_aspectRatio_to_string(pkt->aspectRatio),
-		pkt->barDataFlags,
-		pkt->barDataValue[0],
-		pkt->barDataValue[1]
-		);
+	PRINT_DEBUG("%s() AFD: %s Aspect Ratio: %s Flags: 0x%x Value1: 0x%x Value2: 0x%x\n", __func__,
+		    klvanc_afd_to_string(pkt->afd),
+		    klvanc_aspectRatio_to_string(pkt->aspectRatio),
+		    pkt->barDataFlags,
+		    pkt->barDataValue[0],
+		    pkt->barDataValue[1]);
 
 	return KLAPI_OK;
 }
@@ -139,7 +138,7 @@ int parse_AFD(struct klvanc_context_s *ctx,
 			      struct klvanc_packet_header_s *hdr, void **pp)
 {
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_afd_s *pkt = calloc(1, sizeof(*pkt));
 	if (!pkt)

--- a/src/core-packet-eia_608.c
+++ b/src/core-packet-eia_608.c
@@ -32,18 +32,18 @@ int klvanc_dump_EIA_608(struct klvanc_context_s *ctx, void *p)
 	struct klvanc_packet_eia_608_s *pkt = p;
 
 	if (ctx->verbose)
-		printf("%s() %p\n", __func__, (void *)pkt);
+		PRINT_DEBUG("%s() %p\n", __func__, (void *)pkt);
 
-	printf("%s() EIA608: %02x %02x %02x : marker-bits %02x cc_valid %d cc_type %d cc_data_1 %02x cc_data_2 %02x\n",
-		__func__,
-		pkt->payload[0],
-		pkt->payload[1],
-		pkt->payload[2],
-		pkt->marker_bits,
-		pkt->cc_valid,
-		pkt->cc_type,
-		pkt->cc_data_1,
-		pkt->cc_data_2);
+	PRINT_DEBUG("%s() EIA608: %02x %02x %02x : marker-bits %02x cc_valid %d cc_type %d cc_data_1 %02x cc_data_2 %02x\n",
+		    __func__,
+		    pkt->payload[0],
+		    pkt->payload[1],
+		    pkt->payload[2],
+		    pkt->marker_bits,
+		    pkt->cc_valid,
+		    pkt->cc_type,
+		    pkt->cc_data_1,
+		    pkt->cc_data_2);
 
 	return KLAPI_OK;
 }
@@ -51,7 +51,7 @@ int klvanc_dump_EIA_608(struct klvanc_context_s *ctx, void *p)
 int parse_EIA_608(struct klvanc_context_s *ctx, struct klvanc_packet_header_s *hdr, void **pp)
 {
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_eia_608_s *pkt = calloc(1, sizeof(*pkt));
 	if (!pkt)

--- a/src/core-packet-eia_708b.c
+++ b/src/core-packet-eia_708b.c
@@ -27,9 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define PRINT_DEBUG_MEMBER_INT(m, n) printf("%*c%s = 0x%x\n", n, ' ', #m, m);
-#define PRINT_DEBUG_MEMBER_INT64(m) printf(" %s = 0x%lx\n", #m, m);
-
 static const char *cc_type_lookup(int cc_type)
 {
 	switch (cc_type) {
@@ -108,76 +105,76 @@ int klvanc_dump_EIA_708B(struct klvanc_context_s *ctx, void *p)
 	struct klvanc_packet_eia_708b_s *pkt = p;
 
 	if (ctx->verbose)
-		printf("%s() %p\n", __func__, (void *)pkt);
+		PRINT_DEBUG("%s() %p\n", __func__, (void *)pkt);
 
-	printf(" pkt->header.cdp_identifier = 0x%04x (%s)\n",
-	       pkt->header.cdp_identifier,
-	       pkt->header.cdp_identifier == 0x9669 ? "VALID" : "INVALID");
+	PRINT_DEBUG(" pkt->header.cdp_identifier = 0x%04x (%s)\n",
+		    pkt->header.cdp_identifier,
+		    pkt->header.cdp_identifier == 0x9669 ? "VALID" : "INVALID");
 
-	PRINT_DEBUG_MEMBER_INT(pkt->header.cdp_length, 1);
-	printf(" pkt->header.cdp_frame_rate = 0x%02x (%s FPS)\n",
-	       pkt->header.cdp_frame_rate,
-	       cc_framerate_lookup(pkt->header.cdp_frame_rate));
-	PRINT_DEBUG_MEMBER_INT(pkt->header.time_code_present, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.ccdata_present, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.svcinfo_present, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.svc_info_start, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.svc_info_change, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.svc_info_complete, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.caption_service_active, 1);
-	PRINT_DEBUG_MEMBER_INT(pkt->header.cdp_hdr_sequence_cntr, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.cdp_length, 1);
+	PRINT_DEBUG(" pkt->header.cdp_frame_rate = 0x%02x (%s FPS)\n",
+		    pkt->header.cdp_frame_rate,
+		    cc_framerate_lookup(pkt->header.cdp_frame_rate));
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.time_code_present, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.ccdata_present, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.svcinfo_present, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.svc_info_start, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.svc_info_change, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.svc_info_complete, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.caption_service_active, 1);
+	PRINT_DEBUG_MEMBER_INTI(pkt->header.cdp_hdr_sequence_cntr, 1);
 	if (pkt->header.time_code_present) {
 
 	}
 
 	if (pkt->header.ccdata_present) {
-		printf("  pkt->ccdata.ccdata_id = 0x%02x (%s)\n",
-		       pkt->ccdata.ccdata_id,
-		       pkt->ccdata.ccdata_id == 0x72 ? "VALID" : "INVALID");
-		PRINT_DEBUG_MEMBER_INT(pkt->ccdata.cc_count, 2);
+		PRINT_DEBUG("  pkt->ccdata.ccdata_id = 0x%02x (%s)\n",
+			    pkt->ccdata.ccdata_id,
+			    pkt->ccdata.ccdata_id == 0x72 ? "VALID" : "INVALID");
+		PRINT_DEBUG_MEMBER_INTI(pkt->ccdata.cc_count, 2);
 		for (int i = 0; i < pkt->ccdata.cc_count; i++) {
-			printf("  pkt->ccdata.cc[%d]\n", i);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccdata.cc[i].cc_valid, 3);
-			printf("   pkt->ccdata.cc[i].cc_type = 0x%02x (%s)\n",
-			       pkt->ccdata.cc[i].cc_type,
-			       cc_type_lookup(pkt->ccdata.cc[i].cc_type));
-			PRINT_DEBUG_MEMBER_INT(pkt->ccdata.cc[i].cc_data[0], 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccdata.cc[i].cc_data[1], 3);
+			PRINT_DEBUG("  pkt->ccdata.cc[%d]\n", i);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccdata.cc[i].cc_valid, 3);
+			PRINT_DEBUG("   pkt->ccdata.cc[i].cc_type = 0x%02x (%s)\n",
+				    pkt->ccdata.cc[i].cc_type,
+				    cc_type_lookup(pkt->ccdata.cc[i].cc_type));
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccdata.cc[i].cc_data[0], 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccdata.cc[i].cc_data[1], 3);
 		}
 	}
 
 	if (pkt->header.svcinfo_present) {
-		printf("  pkt->svcinfo.ccsvcinfo_id = 0x%02x (%s)\n",
-		       pkt->ccsvc.ccsvcinfo_id,
-		       pkt->ccsvc.ccsvcinfo_id == 0x73 ? "VALID" : "INVALID");
-		PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc_info_start, 2);
-		PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc_info_change, 2);
-		PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc_info_complete, 2);
-		PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc_count, 2);
+		PRINT_DEBUG("  pkt->svcinfo.ccsvcinfo_id = 0x%02x (%s)\n",
+			    pkt->ccsvc.ccsvcinfo_id,
+			    pkt->ccsvc.ccsvcinfo_id == 0x73 ? "VALID" : "INVALID");
+		PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc_info_start, 2);
+		PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc_info_change, 2);
+		PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc_info_complete, 2);
+		PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc_count, 2);
 		for (int i = 0; i < pkt->ccsvc.svc_count; i++) {
-			printf("  pkt->ccssvc.entry[%d]\n", i);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].caption_service_number, 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].svc_data_byte[0], 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].svc_data_byte[1], 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].svc_data_byte[2], 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].svc_data_byte[3], 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].svc_data_byte[4], 3);
-			PRINT_DEBUG_MEMBER_INT(pkt->ccsvc.svc[i].svc_data_byte[5], 3);
+			PRINT_DEBUG("  pkt->ccssvc.entry[%d]\n", i);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].caption_service_number, 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].svc_data_byte[0], 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].svc_data_byte[1], 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].svc_data_byte[2], 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].svc_data_byte[3], 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].svc_data_byte[4], 3);
+			PRINT_DEBUG_MEMBER_INTI(pkt->ccsvc.svc[i].svc_data_byte[5], 3);
 		}
 	}
 
 	/* FIXME: add support for "future_section" (Sec 11.2.7) */
 
-	printf(" pkt->footer.cdp_footer_id = 0x%02x (%s)\n",
-	       pkt->footer.cdp_footer_id,
-	       pkt->footer.cdp_footer_id == 0x74 ? "VALID" : "INVALID");
-	printf(" pkt->footer.cdp_ftr_sequence_cntr = 0x%02x (%s)\n",
-	       pkt->footer.cdp_ftr_sequence_cntr,
-	       pkt->footer.cdp_ftr_sequence_cntr == pkt->header.cdp_hdr_sequence_cntr ? "Matches Header" : "INVALID: does not match header");
+	PRINT_DEBUG(" pkt->footer.cdp_footer_id = 0x%02x (%s)\n",
+		    pkt->footer.cdp_footer_id,
+		    pkt->footer.cdp_footer_id == 0x74 ? "VALID" : "INVALID");
+	PRINT_DEBUG(" pkt->footer.cdp_ftr_sequence_cntr = 0x%02x (%s)\n",
+		    pkt->footer.cdp_ftr_sequence_cntr,
+		    pkt->footer.cdp_ftr_sequence_cntr == pkt->header.cdp_hdr_sequence_cntr ? "Matches Header" : "INVALID: does not match header");
 
-	printf(" pkt->footer.packet_checksum = 0x%02x (%s)\n",
-	       pkt->footer.packet_checksum,
-	       pkt->checksum_valid == 1 ? "VALID" : "INVALID");
+	PRINT_DEBUG(" pkt->footer.packet_checksum = 0x%02x (%s)\n",
+		    pkt->footer.packet_checksum,
+		    pkt->checksum_valid == 1 ? "VALID" : "INVALID");
 
 	return KLAPI_OK;
 }
@@ -187,7 +184,7 @@ int parse_EIA_708B(struct klvanc_context_s *ctx, struct klvanc_packet_header_s *
 	struct klbs_context_s *bs = klbs_alloc();
 
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_eia_708b_s *pkt = calloc(1, sizeof(*pkt));
 	if (!pkt)

--- a/src/core-packet-kl_u64le_counter.c
+++ b/src/core-packet-kl_u64le_counter.c
@@ -31,11 +31,11 @@
 int klvanc_dump_KL_U64LE_COUNTER(struct klvanc_context_s *ctx, void *p)
 {
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_kl_u64le_counter_s *pkt = p;
 
-	printf("%s() KL_U64LE_COUNTER: %" PRIu64 " [%" PRIx64 "]\n", __func__, pkt->counter, pkt->counter);
+	PRINT_DEBUG("%s() KL_U64LE_COUNTER: %" PRIu64 " [%" PRIx64 "]\n", __func__, pkt->counter, pkt->counter);
 
 	return KLAPI_OK;
 }
@@ -43,7 +43,7 @@ int klvanc_dump_KL_U64LE_COUNTER(struct klvanc_context_s *ctx, void *p)
 int parse_KL_U64LE_COUNTER(struct klvanc_context_s *ctx, struct klvanc_packet_header_s *hdr, void **pp)
 {
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_kl_u64le_counter_s *pkt = calloc(1, sizeof(*pkt));
 	if (!pkt)

--- a/src/core-packet-scte_104.c
+++ b/src/core-packet-scte_104.c
@@ -1014,7 +1014,7 @@ int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_context_s *ctx, struct 
 	if (pkt->so_msg.opID != 0xffff) {
 		/* We don't currently support anything but Multiple Operation
 		   Messages */
-//		PRINT_ERR("msg opid not 0xffff.  Provided=0x%x\n", pkt->so_msg.opID);
+		PRINT_ERR("msg opid not 0xffff.  Provided=0x%x\n", pkt->so_msg.opID);
 		return -1;
 	}
 

--- a/src/core-packet-scte_104.c
+++ b/src/core-packet-scte_104.c
@@ -28,9 +28,6 @@
 #include <string.h>
 #include <inttypes.h>
 
-#define PRINT_DEBUG_MEMBER_INT(m) printf(" %s = 0x%x\n", #m, m);
-#define PRINT_DEBUG_MEMBER_INT64(m) printf(" %s = 0x%" PRIx64 "\n", #m, m);
-
 static const char *gpiEdge(unsigned char edge)
 {
 	switch (edge) {
@@ -40,30 +37,30 @@ static const char *gpiEdge(unsigned char edge)
 	}
 }
 
-static void print_debug_member_timestamp(struct klvanc_multiple_operation_message_timestamp *ts)
+static void print_debug_member_timestamp(struct klvanc_context_s *ctx, struct klvanc_multiple_operation_message_timestamp *ts)
 {
-	printf( " m->timestamp type = 0x%02x ", ts->time_type);
+	PRINT_DEBUG( " m->timestamp type = 0x%02x ", ts->time_type);
 	switch (ts->time_type) {
 	case 1:
-		printf("(UTC Time)\n");
-		printf("   m->timestamp value = %d.%06d (UTC seconds)\n", ts->time_type_1.UTC_seconds, ts->time_type_1.UTC_microseconds);
+		PRINT_DEBUG("(UTC Time)\n");
+		PRINT_DEBUG("   m->timestamp value = %d.%06d (UTC seconds)\n", ts->time_type_1.UTC_seconds, ts->time_type_1.UTC_microseconds);
                 break;
         case 2:
-		printf("(SMPTE VITC timecode)\n");
-		printf("   m->timestamp value = %02d:%02d:%02d:%02d (hh:mm:ss:ff)\n", ts->time_type_2.hours, ts->time_type_2.minutes,
+		PRINT_DEBUG("(SMPTE VITC timecode)\n");
+		PRINT_DEBUG("   m->timestamp value = %02d:%02d:%02d:%02d (hh:mm:ss:ff)\n", ts->time_type_2.hours, ts->time_type_2.minutes,
 		       ts->time_type_2.seconds, ts->time_type_2.frames);
                 break;
         case 3:
-		printf("(GPI input)\n");
-		printf("   m->timestamp GPI number = %d\n", ts->time_type_3.GPI_number);
-		printf("   m->timestamp GPI edge = 0x%02x (%s)\n", ts->time_type_3.GPI_edge, gpiEdge(ts->time_type_3.GPI_edge));
+		PRINT_DEBUG("(GPI input)\n");
+		PRINT_DEBUG("   m->timestamp GPI number = %d\n", ts->time_type_3.GPI_number);
+		PRINT_DEBUG("   m->timestamp GPI edge = 0x%02x (%s)\n", ts->time_type_3.GPI_edge, gpiEdge(ts->time_type_3.GPI_edge));
                 break;
         case 0:
                 /* The spec says no time is defined, this is a legitimate state. */
-		printf("(none)\n");
+		PRINT_DEBUG("(none)\n");
 		break;
         default:
-		printf("(unknown/unsupported)\n");
+		PRINT_DEBUG("(unknown/unsupported)\n");
         }
 }
 
@@ -207,15 +204,15 @@ static const char *seg_device_restrictions(unsigned char val)
 	}
 }
 
-static void hexdump(unsigned char *buf, unsigned int len, int bytesPerRow /* Typically 16 */, char *indent)
+static void hexdump(struct klvanc_context_s *ctx, unsigned char *buf, unsigned int len, int bytesPerRow /* Typically 16 */, char *indent)
 {
-	printf("%s", indent);
+	PRINT_DEBUG("%s", indent);
 	for (unsigned int i = 0; i < len; i++)
-		printf("%02x%s", buf[i], ((i + 1) % bytesPerRow) ? " " : "\n%s");
-	printf("\n");
+		PRINT_DEBUG("%02x%s", buf[i], ((i + 1) % bytesPerRow) ? " " : "\n%s");
+	PRINT_DEBUG("\n");
 }
 
-static unsigned char *parse_splice_request_data(unsigned char *p,
+static unsigned char *parse_splice_request_data(struct klvanc_context_s *ctx, unsigned char *p,
 						struct klvanc_splice_request_data *d)
 {
 	d->splice_insert_type  = *(p++);
@@ -237,7 +234,7 @@ static unsigned char *parse_splice_request_data(unsigned char *p,
 		break;
 	default:
 		/* We don't support this splice command */
-		fprintf(stderr, "%s() splice_insert_type 0x%x [%s], error.\n", __func__,
+		PRINT_ERR("%s() splice_insert_type 0x%x [%s], error.\n", __func__,
 			d->splice_insert_type,
 		spliceInsertTypeName(d->splice_insert_type));
 	}
@@ -622,7 +619,7 @@ static int gen_time_descriptor(struct klvanc_time_descriptor_data *d,
 	return 0;
 }
 
-static unsigned char *parse_mom_timestamp(unsigned char *p,
+static unsigned char *parse_mom_timestamp(struct klvanc_context_s *ctx, unsigned char *p,
 					  struct klvanc_multiple_operation_message_timestamp *ts)
 {
 	ts->time_type = *(p++);
@@ -648,7 +645,7 @@ static unsigned char *parse_mom_timestamp(unsigned char *p,
 		/* The spec says no time is defined, this is a legitimate state. */
 		break;
 	default:
-		fprintf(stderr, "%s() unsupported time_type 0x%x, assuming no time.\n", __func__, ts->time_type);
+		PRINT_ERR("%s() unsupported time_type 0x%x, assuming no time.\n", __func__, ts->time_type);
 	}
 
 	return p;
@@ -658,37 +655,37 @@ static int dump_mom(struct klvanc_context_s *ctx, struct klvanc_packet_scte_104_
 {
 	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
 
-	printf("SCTE104 multiple_operation_message struct\n");
+	PRINT_DEBUG("SCTE104 multiple_operation_message struct\n");
 	PRINT_DEBUG_MEMBER_INT(pkt->payloadDescriptorByte);
 
 	PRINT_DEBUG_MEMBER_INT(m->rsvd);
-	printf("    rsvd = %s\n", m->rsvd == 0xFFFF ? "Multiple_Ops (Reserved)" : "UNSUPPORTED");
+	PRINT_DEBUG("    rsvd = %s\n", m->rsvd == 0xFFFF ? "Multiple_Ops (Reserved)" : "UNSUPPORTED");
 	PRINT_DEBUG_MEMBER_INT(m->messageSize);
 	PRINT_DEBUG_MEMBER_INT(m->protocol_version);
 	PRINT_DEBUG_MEMBER_INT(m->AS_index);
 	PRINT_DEBUG_MEMBER_INT(m->message_number);
 	PRINT_DEBUG_MEMBER_INT(m->DPI_PID_index);
 	PRINT_DEBUG_MEMBER_INT(m->SCTE35_protocol_version);
-	print_debug_member_timestamp(&m->timestamp);
+	print_debug_member_timestamp(ctx, &m->timestamp);
 	PRINT_DEBUG_MEMBER_INT(m->num_ops);
 
 	for (int i = 0; i < m->num_ops; i++) {
 		struct klvanc_multiple_operation_message_operation *o = &m->ops[i];
-		printf("\n opID[%d] = %s\n", i, mom_operationName(o->opID));
+		PRINT_DEBUG("\n opID[%d] = %s\n", i, mom_operationName(o->opID));
 		PRINT_DEBUG_MEMBER_INT(o->opID);
 		PRINT_DEBUG_MEMBER_INT(o->data_length);
 		if (o->data_length)
-			hexdump(o->data, o->data_length, 32, "    ");
+			hexdump(ctx, o->data, o->data_length, 32, "    ");
 		if (o->opID == MO_SPLICE_REQUEST_DATA) {
 			struct klvanc_splice_request_data *d = &o->sr_data;
 			PRINT_DEBUG_MEMBER_INT(d->splice_insert_type);
-			printf("    splice_insert_type = %s\n", spliceInsertTypeName(d->splice_insert_type));
+			PRINT_DEBUG("    splice_insert_type = %s\n", spliceInsertTypeName(d->splice_insert_type));
 			PRINT_DEBUG_MEMBER_INT(d->splice_event_id);
 			PRINT_DEBUG_MEMBER_INT(d->unique_program_id);
 			PRINT_DEBUG_MEMBER_INT(d->pre_roll_time);
-			printf("    pre_roll_time = %d (milliseconds)\n", d->pre_roll_time);
+			PRINT_DEBUG("    pre_roll_time = %d (milliseconds)\n", d->pre_roll_time);
 			PRINT_DEBUG_MEMBER_INT(d->brk_duration);
-			printf("    break_duration = %d (1/10th seconds)\n", d->brk_duration);
+			PRINT_DEBUG("    break_duration = %d (1/10th seconds)\n", d->brk_duration);
 			PRINT_DEBUG_MEMBER_INT(d->avail_num);
 			PRINT_DEBUG_MEMBER_INT(d->avails_expected);
 			PRINT_DEBUG_MEMBER_INT(d->auto_return_flag);
@@ -717,14 +714,14 @@ static int dump_mom(struct klvanc_context_s *ctx, struct klvanc_packet_scte_104_
 			PRINT_DEBUG_MEMBER_INT(d->event_id);
 			PRINT_DEBUG_MEMBER_INT(d->event_cancel_indicator);
 			PRINT_DEBUG_MEMBER_INT(d->duration);
-			printf("    duration = %d (seconds)\n", d->duration);
+			PRINT_DEBUG("    duration = %d (seconds)\n", d->duration);
 			PRINT_DEBUG_MEMBER_INT(d->upid_type);
-			printf(" d->upid_type = 0x%02x (%s)\n", d->upid_type, seg_upid_type(d->upid_type));
+			PRINT_DEBUG(" d->upid_type = 0x%02x (%s)\n", d->upid_type, seg_upid_type(d->upid_type));
 			PRINT_DEBUG_MEMBER_INT(d->upid_length);
 			for (int j = 0; j < d->upid_length; j++) {
 				PRINT_DEBUG_MEMBER_INT(d->upid[j]);
 			}
-			printf(" d->type_id = 0x%02x (%s)\n", d->type_id, seg_type_id(d->type_id));
+			PRINT_DEBUG(" d->type_id = 0x%02x (%s)\n", d->type_id, seg_type_id(d->type_id));
 			PRINT_DEBUG_MEMBER_INT(d->segment_num);
 			PRINT_DEBUG_MEMBER_INT(d->segments_expected);
 			PRINT_DEBUG_MEMBER_INT(d->duration_extension_frames);
@@ -732,7 +729,7 @@ static int dump_mom(struct klvanc_context_s *ctx, struct klvanc_packet_scte_104_
 			PRINT_DEBUG_MEMBER_INT(d->web_delivery_allowed_flag);
 			PRINT_DEBUG_MEMBER_INT(d->no_regional_blackout_flag);
 			PRINT_DEBUG_MEMBER_INT(d->archive_allowed_flag);
-			printf(" d->device_restrictions = 0x%02x (%s)\n", d->device_restrictions,
+			PRINT_DEBUG(" d->device_restrictions = 0x%02x (%s)\n", d->device_restrictions,
 			       seg_device_restrictions(d->device_restrictions));
 		} else if (o->opID == MO_INSERT_TIER_DATA) {
 			struct klvanc_tier_data *d = &o->tier_data;
@@ -756,13 +753,13 @@ static int dump_som(struct klvanc_context_s *ctx, struct klvanc_packet_scte_104_
 #endif
 	struct klvanc_single_operation_message *m = &pkt->so_msg;
 
-	printf("SCTE104 single_operation_message struct\n");
+	PRINT_DEBUG("SCTE104 single_operation_message struct\n");
 	PRINT_DEBUG_MEMBER_INT(pkt->payloadDescriptorByte);
 
 	PRINT_DEBUG_MEMBER_INT(m->opID);
-	printf("   opID = %s\n", som_operationName(m->opID));
+	PRINT_DEBUG("   opID = %s\n", som_operationName(m->opID));
 	PRINT_DEBUG_MEMBER_INT(m->messageSize);
-	printf("   message_size = %d bytes\n", m->messageSize);
+	PRINT_DEBUG("   message_size = %d bytes\n", m->messageSize);
 	PRINT_DEBUG_MEMBER_INT(m->result);
 	PRINT_DEBUG_MEMBER_INT(m->result_extension);
 	PRINT_DEBUG_MEMBER_INT(m->protocol_version);
@@ -773,22 +770,22 @@ static int dump_som(struct klvanc_context_s *ctx, struct klvanc_packet_scte_104_
 #ifdef SPLICE_REQUEST_SINGLE
 	if (m->opID == SO_INIT_REQUEST_DATA) {
 		PRINT_DEBUG_MEMBER_INT(d->splice_insert_type);
-		printf("   splice_insert_type = %s\n", spliceInsertTypeName(d->splice_insert_type));
+		PRINT_DEBUG("   splice_insert_type = %s\n", spliceInsertTypeName(d->splice_insert_type));
 		PRINT_DEBUG_MEMBER_INT(d->splice_event_id);
 		PRINT_DEBUG_MEMBER_INT(d->unique_program_id);
 		PRINT_DEBUG_MEMBER_INT(d->pre_roll_time);
 		PRINT_DEBUG_MEMBER_INT(d->brk_duration);
-		printf("   break_duration = %d (1/10th seconds)\n", d->brk_duration);
+		PRINT_DEBUG("   break_duration = %d (1/10th seconds)\n", d->brk_duration);
 		PRINT_DEBUG_MEMBER_INT(d->avail_num);
 		PRINT_DEBUG_MEMBER_INT(d->avails_expected);
 		PRINT_DEBUG_MEMBER_INT(d->auto_return_flag);
 	} else
 #endif
-		printf("   unsupported m->opID = 0x%x\n", m->opID);
+		PRINT_DEBUG("   unsupported m->opID = 0x%x\n", m->opID);
 
 	for (int i = 0; i < pkt->payloadLengthBytes; i++)
-		printf("%02x ", pkt->payload[i]);
-	printf("\n");
+		PRINT_DEBUG("%02x ", pkt->payload[i]);
+	PRINT_DEBUG("\n");
 
 	return KLAPI_OK;
 }
@@ -822,7 +819,7 @@ int klvanc_dump_SCTE_104(struct klvanc_context_s *ctx, void *p)
 	struct klvanc_packet_scte_104_s *pkt = p;
 
 	if (ctx->verbose)
-		printf("%s() %p\n", __func__, (void *)pkt);
+		PRINT_DEBUG("%s() %p\n", __func__, (void *)pkt);
 
 	if (pkt->so_msg.opID == SO_INIT_REQUEST_DATA)
 		return dump_som(ctx, pkt);
@@ -850,7 +847,7 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 		   struct klvanc_packet_header_s *hdr, void **pp)
 {
 	if (ctx->verbose)
-		printf("%s()\n", __func__);
+		PRINT_DEBUG("%s()\n", __func__);
 
 	struct klvanc_packet_scte_104_s *pkt = calloc(1, sizeof(*pkt));
 	if (!pkt)
@@ -923,7 +920,7 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 			break;
 		default:
 			/* We don't support this splice command */
-			fprintf(stderr, "%s() splice_insert_type 0x%x, error.\n", __func__, d->splice_insert_type);
+			PRINT_ERR("%s() splice_insert_type 0x%x, error.\n", __func__, d->splice_insert_type);
 			free(pkt);
 			return -1;
 		}
@@ -939,12 +936,12 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 		mom->SCTE35_protocol_version = pkt->payload[9];
 
 		unsigned char *p = &pkt->payload[10];
-		p = parse_mom_timestamp(p, &mom->timestamp);
+		p = parse_mom_timestamp(ctx, p, &mom->timestamp);
 		
 		mom->num_ops = *(p++);
 		mom->ops = calloc(mom->num_ops, sizeof(struct klvanc_multiple_operation_message_operation));
 		if (!mom->ops) {
-			fprintf(stderr, "%s() unable to allocate momo ram, error.\n", __func__);
+			PRINT_ERR("%s() unable to allocate momo ram, error.\n", __func__);
 			free(pkt);
 			return -1;
 		}
@@ -955,14 +952,14 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 			o->data_length = *(p + 2) << 8 | *(p + 3);
 			o->data = malloc(o->data_length);
 			if (!o->data) {
-				fprintf(stderr, "%s() Unable to allocate memory for mom op, error.\n", __func__);
+				PRINT_ERR("%s() Unable to allocate memory for mom op, error.\n", __func__);
 			} else {
 				memcpy(o->data, p + 4, o->data_length);
 			}
 			p += (4 + o->data_length);
 
 			if (o->opID == MO_SPLICE_REQUEST_DATA)
-				parse_splice_request_data(o->data, &o->sr_data);
+				parse_splice_request_data(ctx, o->data, &o->sr_data);
 			else if (o->opID == MO_INSERT_DESCRIPTOR_REQUEST_DATA)
 				parse_descriptor_request_data(o->data, &o->descriptor_data,
 					o->data_length - 1);
@@ -982,8 +979,8 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 				parse_time_descriptor(o->data, &o->time_data);
 
 #if 0
-			printf("opID = 0x%04x [%s], length = 0x%04x : ", o->opID, mom_operationName(o->opID), o->data_length);
-			hexdump(o->data, o->data_length, 32, "");
+			PRINT_DEBUG("opID = 0x%04x [%s], length = 0x%04x : ", o->opID, mom_operationName(o->opID), o->data_length);
+			hexdump(ctx, o->data, o->data_length, 32, "");
 #endif
 		}
 
@@ -993,7 +990,7 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 		 */
 	}
 	else {
-		fprintf(stderr, "%s() Unsupported opID = %x, error.\n", __func__, m->opID);
+		PRINT_ERR("%s() Unsupported opID = %x, error.\n", __func__, m->opID);
 		free(pkt);
 		return -1;
 	}
@@ -1005,7 +1002,7 @@ int parse_SCTE_104(struct klvanc_context_s *ctx,
 	return KLAPI_OK;
 }
 
-int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
+int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_context_s *ctx, struct klvanc_packet_scte_104_s *pkt,
 					   uint8_t **bytes, uint16_t *byteCount)
 {
 	struct klvanc_multiple_operation_message *m;
@@ -1017,7 +1014,7 @@ int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
 	if (pkt->so_msg.opID != 0xffff) {
 		/* We don't currently support anything but Multiple Operation
 		   Messages */
-		fprintf(stderr, "msg opid not 0xffff.  Provided=0x%x\n", pkt->so_msg.opID);
+//		PRINT_ERR("msg opid not 0xffff.  Provided=0x%x\n", pkt->so_msg.opID);
 		return -1;
 	}
 
@@ -1063,7 +1060,7 @@ int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
 		/* No time standard defined */
 		break;
 	default:
-		fprintf(stderr, "%s() unsupported time_type 0x%x, assuming no time.\n",
+		PRINT_ERR("%s() unsupported time_type 0x%x, assuming no time.\n",
 			__func__, ts->time_type);
 		break;
 	}
@@ -1103,7 +1100,7 @@ int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
 			gen_time_descriptor(&o->time_data, &o->data, &o->data_length);
 			break;
 		default:
-			fprintf(stderr, "Unknown operation type 0x%04x\n", o->opID);
+			PRINT_ERR("Unknown operation type 0x%04x\n", o->opID);
 			continue;
 		}
 		/* FIXME */
@@ -1124,12 +1121,12 @@ int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
 	(*bytes)[4] = buffer_size & 0xff;
 
 #if 0
-	printf("Resulting buffer size=%d\n", klbs_get_byte_count(bs));
-	printf(" ->payload  = ");
+	PRINT_DEBUG("Resulting buffer size=%d\n", klbs_get_byte_count(bs));
+	PRINT_DEBUG(" ->payload  = ");
 	for (int i = 0; i < klbs_get_byte_count(bs); i++) {
-		printf("%02x ", (*bytes)[i]);
+		PRINT_DEBUG("%02x ", (*bytes)[i]);
 	}
-	printf("\n");
+	PRINT_DEBUG("\n");
 #endif
 
 	*byteCount = klbs_get_byte_count(bs);
@@ -1138,14 +1135,15 @@ int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
 	return 0;
 }
 
-int klvanc_convert_SCTE_104_to_words(struct klvanc_packet_scte_104_s *pkt,
+int klvanc_convert_SCTE_104_to_words(struct klvanc_context_s *ctx,
+				     struct klvanc_packet_scte_104_s *pkt,
 				     uint16_t **words, uint16_t *wordCount)
 {
 	uint8_t *buf;
 	uint16_t byteCount;
 	int ret;
 
-	ret = klvanc_convert_SCTE_104_to_packetBytes(pkt, &buf, &byteCount);
+	ret = klvanc_convert_SCTE_104_to_packetBytes(ctx, pkt, &buf, &byteCount);
 	if (ret != 0)
 		return -1;
 

--- a/src/core-packets.c
+++ b/src/core-packets.c
@@ -36,7 +36,7 @@ static int isValidHeader(struct klvanc_context_s *ctx, unsigned short *arr, unsi
 	}
 
 	if (ctx->verbose > 1)
-		printf("%04x %04x %04x %s\n", *(arr + 0), *(arr + 1), *(arr + 2), ret ? "valid": "invalid");
+		PRINT_DEBUG("%04x %04x %04x %s\n", *(arr + 0), *(arr + 1), *(arr + 2), ret ? "valid": "invalid");
 	return ret;
 }
 
@@ -152,45 +152,46 @@ static int parse(struct klvanc_context_s *ctx, unsigned short *arr, unsigned int
 	return KLAPI_OK;
 }
 
-void vanc_dump_words_console(uint16_t *vanc, int maxlen, unsigned int linenr, int onlyvalid)
+void klvanc_dump_words_console(struct klvanc_context_s *ctx, uint16_t *vanc,
+			       int maxlen, unsigned int linenr, int onlyvalid)
 {
 	if (onlyvalid && (*(vanc + 1) != 0x3ff) && (*(vanc + 2) != 0x3ff))
 		return;
 
-	fprintf(stderr, "LineNr: %03d ADF: [%03x][%03x][%03x] DID: [%03x] DBN/SDID: [%03x] DC: [%03x]\n",
-		linenr, *(vanc + 0), *(vanc + 1), *(vanc + 2), *(vanc + 3),
-		*(vanc + 4), *(vanc + 5));
+	PRINT_DEBUG("LineNr: %03d ADF: [%03x][%03x][%03x] DID: [%03x] DBN/SDID: [%03x] DC: [%03x]\n",
+		    linenr, *(vanc + 0), *(vanc + 1), *(vanc + 2), *(vanc + 3),
+		    *(vanc + 4), *(vanc + 5));
 
-	fprintf(stderr, "           Desc: %s [SMPTE %s]\n",
-		klvanc_didLookupDescription(*(vanc + 3) & 0xff, *(vanc + 4) & 0xff),
-		klvanc_didLookupSpecification(*(vanc + 3) & 0xff, *(vanc + 4) & 0xff));
+	PRINT_DEBUG("           Desc: %s [SMPTE %s]\n",
+		    klvanc_didLookupDescription(*(vanc + 3) & 0xff, *(vanc + 4) & 0xff),
+		    klvanc_didLookupSpecification(*(vanc + 3) & 0xff, *(vanc + 4) & 0xff));
 
 	/* Spec says DC is a maximum number of 255 words */
 	int i, words = *(vanc + 5) & 0xff;
-	fprintf(stderr, "           Data: ");
+	PRINT_DEBUG("           Data: ");
 	for (i = 6; i < (6 + words); i++) {
-		fprintf(stderr, "[%03x] ", *(vanc + i));
+		PRINT_DEBUG("[%03x] ", *(vanc + i));
 	}
-	fprintf(stderr, "\n             CS: [%03x]\n", *(vanc + i));
+	PRINT_DEBUG("\n             CS: [%03x]\n", *(vanc + i));
 }
 
 void klvanc_dump_packet_console(struct klvanc_context_s *ctx, struct klvanc_packet_header_s *hdr)
 {
-	printf("hdr->type   = %d\n", hdr->type);
-	printf(" ->adf      = 0x%04x/0x%04x/0x%04x\n", hdr->adf[0], hdr->adf[1], hdr->adf[2]);
-	printf(" ->did/sdid = 0x%02x / 0x%02x [%s %s] via SDI line %d\n",
-		hdr->did,
-		hdr->dbnsdid,
-		klvanc_didLookupSpecification(hdr->did, hdr->dbnsdid),
-		klvanc_didLookupDescription(hdr->did, hdr->dbnsdid),
-		hdr->lineNr);
-	printf(" ->h_offset = %d\n", hdr->horizontalOffset);
-	printf(" ->checksum = 0x%04x (%s)\n", hdr->checksum, hdr->checksumValid ? "VALID" : "INVALID");
-	printf(" ->payloadLengthWords = %d\n", hdr->payloadLengthWords);
-	printf(" ->payload  = ");
+	PRINT_DEBUG("hdr->type   = %d\n", hdr->type);
+	PRINT_DEBUG(" ->adf      = 0x%04x/0x%04x/0x%04x\n", hdr->adf[0], hdr->adf[1], hdr->adf[2]);
+	PRINT_DEBUG(" ->did/sdid = 0x%02x / 0x%02x [%s %s] via SDI line %d\n",
+		    hdr->did,
+		    hdr->dbnsdid,
+		    klvanc_didLookupSpecification(hdr->did, hdr->dbnsdid),
+		    klvanc_didLookupDescription(hdr->did, hdr->dbnsdid),
+		    hdr->lineNr);
+	PRINT_DEBUG(" ->h_offset = %d\n", hdr->horizontalOffset);
+	PRINT_DEBUG(" ->checksum = 0x%04x (%s)\n", hdr->checksum, hdr->checksumValid ? "VALID" : "INVALID");
+	PRINT_DEBUG(" ->payloadLengthWords = %d\n", hdr->payloadLengthWords);
+	PRINT_DEBUG(" ->payload  = ");
 	for (int i = 0; i < hdr->payloadLengthWords; i++)
-		printf("%02x ", sanitizeWord(hdr->payload[i]));
-	printf("\n");
+		PRINT_DEBUG("%02x ", sanitizeWord(hdr->payload[i]));
+	PRINT_DEBUG("\n");
 }
 
 int klvanc_packet_parse(struct klvanc_context_s *ctx, unsigned int lineNr, unsigned short *arr, unsigned int len)
@@ -202,7 +203,7 @@ int klvanc_packet_parse(struct klvanc_context_s *ctx, unsigned int lineNr, unsig
 
 	if (len > 16384) {
 		/* Safety */
-		fprintf(stderr, "%s() length %d exceeds 16384, ignoring.\n", __func__, len);
+		PRINT_ERR("%s() length %d exceeds 16384, ignoring.\n", __func__, len);
 		return -EINVAL;
 	}
 
@@ -241,12 +242,12 @@ int klvanc_packet_parse(struct klvanc_context_s *ctx, unsigned int lineNr, unsig
 				if (ctx->verbose == 2) {
 					ret = dumpByType(ctx, decodedPacket);
 					if (ret < 0) {
-						fprintf(stderr, "Failed to dump by type, missing dumper function?\n");
+						PRINT_ERR("Failed to dump by type, missing dumper function?\n");
 					}
 				}
 			} else {
 				if (klrestricted_code_path_block_execute(&ctx->rcp_failedToDecode)) {
-					fprintf(stderr, "Failed parsing by type\n");
+					PRINT_ERR("Failed parsing by type\n");
 					klvanc_dump_packet_console(ctx, hdr);
 				}
 			}

--- a/src/core-private.h
+++ b/src/core-private.h
@@ -76,4 +76,11 @@ extern void klvanc_cache_free(struct klvanc_context_s *ctx);
 extern int  klvanc_cache_update(struct klvanc_context_s *ctx,
 				struct klvanc_packet_header_s *pkt);
 
+/* Logging Macros */
+#define PRINT_ERR(...) if (ctx->log_cb) ctx->log_cb(NULL, LIBKLVANC_LOGLEVEL_ERR, __VA_ARGS__);
+#define PRINT_DEBUG(...) if (ctx->log_cb) ctx->log_cb(NULL, LIBKLVANC_LOGLEVEL_DEBUG, __VA_ARGS__);
+#define PRINT_DEBUG_MEMBER_INT(m) if (ctx->log_cb) ctx->log_cb(NULL, LIBKLVANC_LOGLEVEL_DEBUG, " %s = 0x%x\n", #m, m);
+#define PRINT_DEBUG_MEMBER_INTI(m, n) if (ctx->log_cb) ctx->log_cb(NULL, LIBKLVANC_LOGLEVEL_DEBUG, "%*c%s = 0x%x\n", n, ' ', #m, m);
+#define PRINT_DEBUG_MEMBER_INT64(m) if (ctx->log_cb) ctx->log_cb(NULL, LIBKLVANC_LOGLEVEL_DEBUG, " %s = 0x%" PRIx64 "\n", #m, m);
+
 #endif

--- a/src/core.c
+++ b/src/core.c
@@ -27,6 +27,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Default logging implementation just writes to stderr */
+static void vanc_default_logger(void *ctx, int level, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
+}
+
 int klvanc_context_dump(struct klvanc_context_s *ctx)
 {
 	VALIDATE(ctx);
@@ -49,6 +58,9 @@ int klvanc_context_create(struct klvanc_context_s **ctx)
 
 	if (ret == KLAPI_OK)
 		*ctx = p;
+
+	/* Set the default logger */
+	(*ctx)->log_cb = vanc_default_logger;
 
 	return ret;
 }

--- a/src/libklvanc/vanc-lines.h
+++ b/src/libklvanc/vanc-lines.h
@@ -105,8 +105,8 @@ void klvanc_line_free(struct klvanc_line_s *line);
  * @return      0 - Success
  * @return      -ENOMEM - insufficient memory to store the VANC packet
  */
-int klvanc_line_insert(struct klvanc_line_set_s *vanc_lines, uint16_t *pixels,
-		      int pixel_width, int line_number, int horizontal_offset);
+int klvanc_line_insert(struct klvanc_context_s *ctx, struct klvanc_line_set_s *vanc_lines,
+		       uint16_t *pixels, int pixel_width, int line_number, int horizontal_offset);
 
 /**
  * @brief	Generate pixel array representing a fully formed VANC line.  This
@@ -131,7 +131,8 @@ int klvanc_line_insert(struct klvanc_line_set_s *vanc_lines, uint16_t *pixels,
  * @return      0 - Success
  * @return      -ENOMEM - insufficient memory to store the VANC packet
  */
-int klvanc_generate_vanc_line(struct klvanc_line_s *line, uint16_t **out_buf, int *out_len, int line_pixel_width);
+int klvanc_generate_vanc_line(struct klvanc_context_s *ctx, struct klvanc_line_s *line,
+			      uint16_t **out_buf, int *out_len, int line_pixel_width);
 
 #ifdef __cplusplus
 };

--- a/src/libklvanc/vanc-scte_104.h
+++ b/src/libklvanc/vanc-scte_104.h
@@ -333,7 +333,8 @@ void klvanc_free_SCTE_104(struct klvanc_packet_scte_104_s *pkt);
  * @return      < 0 - Error
  * @return      -ENOMEM - Not enough memory to satisfy request
  */
-int klvanc_convert_SCTE_104_to_words(struct klvanc_packet_scte_104_s *pkt,
+int klvanc_convert_SCTE_104_to_words(struct klvanc_context_s *ctx,
+				     struct klvanc_packet_scte_104_s *pkt,
 				     uint16_t **words, uint16_t *wordCount);
 
 /**
@@ -347,7 +348,8 @@ int klvanc_convert_SCTE_104_to_words(struct klvanc_packet_scte_104_s *pkt,
  * @return      < 0 - Error
  * @return      -ENOMEM - Not enough memory to satisfy request
  */
-int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_packet_scte_104_s *pkt,
+int klvanc_convert_SCTE_104_to_packetBytes(struct klvanc_context_s *ctx,
+					   struct klvanc_packet_scte_104_s *pkt,
 					   uint8_t **bytes, uint16_t *byteCount);
 
 int klvanc_SCTE_104_Add_MOM_Op(struct klvanc_packet_scte_104_s *pkt, uint16_t opId,

--- a/src/libklvanc/vanc.h
+++ b/src/libklvanc/vanc.h
@@ -36,6 +36,7 @@
 #define _VANC_H
 
 #include <stdint.h>
+#include <stdarg.h>
 #include <sys/errno.h>
 #include <sys/errno.h>
 #include <libklvanc/klrestricted_code_path.h>
@@ -109,6 +110,8 @@ struct klvanc_context_s
 	struct klvanc_callbacks_s *callbacks;
 	void *callback_context;
 
+	void (*log_cb)(void *p, int level, const char *fmt, ...);
+
 	/* Internal use by the library */
 	void *priv;
 	struct klrestricted_code_path_block_s rcp_failedToDecode;
@@ -127,6 +130,11 @@ struct klvanc_context_s
 	 */
 	struct klvanc_cache_s *cacheLines;
 };
+
+#define LIBKLVANC_LOGLEVEL_ERR 0
+#define LIBKLVANC_LOGLEVEL_WARN 1
+#define LIBKLVANC_LOGLEVEL_INFO 2
+#define LIBKLVANC_LOGLEVEL_DEBUG 3
 
 /**
  * @brief	Create or destroy some basic application/library context.\n
@@ -173,7 +181,7 @@ int klvanc_packet_parse(struct klvanc_context_s *ctx, unsigned int lineNr, unsig
  * @param[in]	unsigned int linenr - SDI line number the array data came from. Used for information / tracking purposes only.
  * @param[in]	int onlyvalid - Brief description goes here.
  */
-void klvanc_dump_words_console(uint16_t *vanc, int maxlen, unsigned int linenr, int onlyvalid);
+void klvanc_dump_words_console(struct klvanc_context_s *ctx, uint16_t *vanc, int maxlen, unsigned int linenr, int onlyvalid);
 
 #include <libklvanc/vanc-afd.h>
 #include <libklvanc/vanc-eia_708b.h>

--- a/tools/demo.c
+++ b/tools/demo.c
@@ -68,7 +68,7 @@ static int cb_SCTE_104(void *callback_context, struct klvanc_context_s *ctx, str
 
 	uint16_t *words;
 	uint16_t wordCount;
-	ret = klvanc_convert_SCTE_104_to_words(pkt, &words, &wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, &words, &wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		return -1;

--- a/tools/genscte104.c
+++ b/tools/genscte104.c
@@ -62,7 +62,7 @@ static int testcase_1(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -117,7 +117,7 @@ static int testcase_2(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -168,7 +168,7 @@ static int testcase_3(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -237,7 +237,7 @@ static int testcase_4(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -290,7 +290,7 @@ static int testcase_5(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -334,7 +334,7 @@ static int testcase_6(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -384,7 +384,7 @@ static int testcase_7(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -436,7 +436,7 @@ static int testcase_8(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -486,7 +486,7 @@ static int testcase_9(struct klvanc_context_s *ctx, uint16_t **words, uint16_t *
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -536,7 +536,7 @@ static int testcase_10(struct klvanc_context_s *ctx, uint16_t **words, uint16_t 
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -586,7 +586,7 @@ static int testcase_11(struct klvanc_context_s *ctx, uint16_t **words, uint16_t 
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);
@@ -636,7 +636,7 @@ static int testcase_12(struct klvanc_context_s *ctx, uint16_t **words, uint16_t 
 		return -1;
 	}
 
-	ret = klvanc_convert_SCTE_104_to_words(pkt, words, wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, words, wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		klvanc_free_SCTE_104(pkt);

--- a/tools/scte104.c
+++ b/tools/scte104.c
@@ -51,7 +51,7 @@ static int cb_SCTE_104(void *callback_context, struct klvanc_context_s *ctx,
 
 	uint16_t *words;
 	uint16_t wordCount;
-	ret = klvanc_convert_SCTE_104_to_words(pkt, &words, &wordCount);
+	ret = klvanc_convert_SCTE_104_to_words(ctx, pkt, &words, &wordCount);
 	if (ret != 0) {
 		fprintf(stderr, "Failed to convert 104 to words: %d\n", ret);
 		return -1;


### PR DESCRIPTION
For cases where the application wants to control what happens with
log messages, have a klvanc_context scoped function pointer where
the user can provide a custom logger.

Convert printf/fprintf to use the new logger object.

Note that this patch changes some underlying API prototypes, since
some of the functions (particularly those related to output as
opposed to parsing) didn't require a VANC context in order to
operate.  Now we require one regardless.