### PR TITLE
Fix creation of malformed AFD packet

### DIFF
--- a/src/core-packet-afd.c
+++ b/src/core-packet-afd.c
@@ -216,6 +216,8 @@ int klvanc_convert_AFD_to_packetBytes(struct klvanc_packet_afd_s *pkt, uint8_t *
 	klbs_write_bits(bs, 0x00, 8); /* Reserved */
 	klbs_write_bits(bs, 0x00, 8); /* Bar Data Flags */
 	klbs_write_bits(bs, 0x00, 8); /* Bar Data Value 1 */
+	klbs_write_bits(bs, 0x00, 8); /* Bar Data Value 1 */
+	klbs_write_bits(bs, 0x00, 8); /* Bar Data Value 2 */
 	klbs_write_bits(bs, 0x00, 8); /* Bar Data Value 2 */
 
 	klbs_write_buffer_complete(bs);


### PR DESCRIPTION
The AFD packets being created didn't have a correctly formatted
bar data region.  While we don't actively support bar data
currently, the packet still has to be the correct size or else
some downstream equipment will discard the entire packet as
invalid.

Write out the extra bytes so that the AFD packet has the correct
size (i.e. 8 bytes).