### PR TITLE
Properly serialize VANC packets to V210 standard definition lines

### DIFF
--- a/src/core-lines.c
+++ b/src/core-lines.c
@@ -192,3 +192,28 @@ int klvanc_generate_vanc_line(struct klvanc_context_s *ctx, struct klvanc_line_s
 	}
 	return 0;
 }
+
+int klvanc_generate_vanc_line_v210(struct klvanc_context_s *ctx,
+                                   struct klvanc_line_s *line,
+                                   uint8_t *out_buf, int line_pixel_width)
+{
+	uint16_t *out_line;
+	int out_len;
+	int result;
+
+	/* Generate the full line taking into account all VANC packets on that line */
+	result = klvanc_generate_vanc_line(ctx, line, &out_line, &out_len,
+					   line_pixel_width);
+	if (result != 0) {
+		return -ENOMEM;
+	}
+
+	/* Repack the 16-bit ints into 10-bit, and push into final buffer */
+	if (line_pixel_width > 720)
+		klvanc_y10_to_v210(out_line, out_buf, out_len);
+	else
+		klvanc_uyvy_to_v210(out_line, out_buf, out_len);
+
+	free(out_line);
+	return 0;
+}

--- a/src/core-pixels.c
+++ b/src/core-pixels.c
@@ -153,3 +153,74 @@ void klvanc_y10_to_v210(uint16_t *src, uint8_t *dst, int width)
 	if (width % 6 > 4)
 		put_le32(&dst, src[w * 6 + 4]);
 }
+
+void klvanc_uyvy_to_v210(uint16_t *src, uint8_t *dst, int width)
+{
+	size_t len = width / 12;
+	size_t w;
+
+	for (w = 0; w < len; w++) {
+		put_le32(&dst, (src[w * 12 + 0]) |
+			 (src[w * 12 + 1] << 10) |
+			 (src[w * 12 + 2] << 20));
+		put_le32(&dst, (src[w * 12 + 3]) |
+			 (src[w * 12 + 4] << 10) |
+			 (src[w * 12 + 5] << 20));
+		put_le32(&dst, (src[w * 12 + 6]) |
+			 (src[w * 12 + 7] << 10) |
+			 (src[w * 12 + 8] << 20));
+		put_le32(&dst, (src[w * 12 + 9]) |
+			 (src[w * 12 + 10] << 10) |
+			 (src[w * 12 + 11] << 20));
+	}
+
+	/* Handle remaining 0-11 bytes if any */
+	if (width % 12 > 2)
+		put_le32(&dst, (src[w * 12 + 0]) |
+			 (src[w * 12 + 1] << 10) |
+			 (src[w * 12 + 2] << 20));
+	else if (width % 12 > 1)
+		put_le32(&dst, (src[w * 12 + 0]) |
+			 (src[w * 12 + 1] << 10) |
+			 (0x200 << 20));
+	else if (width % 12 > 0)
+		put_le32(&dst, (src[w * 12 + 0]) |
+			 (0x040 << 10) |
+			 (0x200 << 20));
+
+	if (width % 12 > 5)
+		put_le32(&dst, (src[w * 12 + 3]) |
+			 (src[w * 12 + 4] << 10) |
+			 (src[w * 12 + 5] << 20));
+	else if (width % 12 > 4)
+		put_le32(&dst, (src[w * 12 + 3]) |
+			 (src[w * 12 + 4] << 10) |
+			 (0x040 << 20));
+	else if (width % 12 > 3)
+		put_le32(&dst, (src[w * 12 + 3]) |
+			 (0x200 << 10) |
+			 (0x040 << 20));
+
+
+	if (width % 12 > 8)
+		put_le32(&dst, (src[w * 12 + 6]) |
+			 (src[w * 12 + 7] << 10) |
+			 (src[w * 12 + 8] << 20));
+	else if (width % 12 > 7)
+		put_le32(&dst, (src[w * 12 + 6]) |
+			 (src[w * 12 + 7] << 10) |
+			 (0x200 << 20));
+	else if (width % 12 > 6)
+		put_le32(&dst, (src[w * 12 + 6]) |
+			 (0x040 << 10) |
+			 (0x200 << 20));
+
+	if (width % 12 > 10)
+		put_le32(&dst, (src[w * 12 + 9]) |
+			 (src[w * 12 + 10] << 10) |
+			 (0x040 << 20));
+	else if (width % 12 > 9)
+		put_le32(&dst, (src[w * 12 + 9]) |
+			 (0x200 << 10) |
+			 (0x040 << 20));
+}

--- a/src/core-pixels.c
+++ b/src/core-pixels.c
@@ -111,7 +111,7 @@ cb0-2 = U
 cr0-2 = V
 XXnn nnnn  nnnn bbbb  bbbb bbaa  aaaa aaaa
 */
-void klvanc_v210_line_to_uyvy_c(uint32_t * src, uint16_t * dst, int width)
+void klvanc_v210_line_to_uyvy_c(const uint32_t * src, uint16_t * dst, int width)
 {
 	uint32_t val;
 	for (int i = 0; i < width; i += 6) {

--- a/src/libklvanc/pixels.h
+++ b/src/libklvanc/pixels.h
@@ -80,6 +80,14 @@ void klvanc_v210_line_to_uyvy_c(uint32_t * src, uint16_t * dst, int width);
  */
 void klvanc_y10_to_v210(uint16_t *src, uint8_t *dst, int width);
 
+/**
+ * @brief	Convert UYVY buffer to V210
+ * @param[in]	uint16_t * src - Array of 16-bit fields containing 10-bit YUV values
+ * @param[out]	uint8_t * dst - Destination containing resulting V210 video
+ * @param[in]	int width - Number of Y pixels in src
+ */
+void klvanc_uyvy_to_v210(uint16_t *src, uint8_t *dst, int width);
+
 #ifdef __cplusplus
 };
 #endif

--- a/src/libklvanc/pixels.h
+++ b/src/libklvanc/pixels.h
@@ -66,11 +66,11 @@ void klvanc_v210_downscale_line_c(uint16_t * src, uint8_t * dst, int lines);
 
 /**
  * @brief	TODO - Brief description goes here.
- * @param[in]	uint32_t * src - Brief description goes here.
+ * @param[in]	const uint32_t * src - Brief description goes here.
  * @param[in]	uint16_t * dst - Brief description goes here.
  * @param[in]	int width - Brief description goes here.
  */
-void klvanc_v210_line_to_uyvy_c(uint32_t * src, uint16_t * dst, int width);
+void klvanc_v210_line_to_uyvy_c(const uint32_t * src, uint16_t * dst, int width);
 
 /**
  * @brief	Convert Y10 buffer to V210

--- a/src/libklvanc/vanc-lines.h
+++ b/src/libklvanc/vanc-lines.h
@@ -114,6 +114,7 @@ int klvanc_line_insert(struct klvanc_context_s *ctx, struct klvanc_line_set_s *v
  *              are no gaps or overlapping packets, and create a final pixel array which
  *              can be colorspace converted and output over SDI.
  *
+ * @param[in]	struct klvanc_context_s *ctx - Context.
  * @param[in]	struct klvanc_line_s *line - the VANC line to operate on
  * @param[out]	uint16_t **out_buf - a pointer to the buffer the function will output into.  The
  *              memory for the buffer will be allocated by the function, and the caller will need
@@ -135,16 +136,17 @@ int klvanc_generate_vanc_line(struct klvanc_context_s *ctx, struct klvanc_line_s
 			      uint16_t **out_buf, int *out_len, int line_pixel_width);
 
 /**
- * @brief	Generate pixel array representing a fully formed VANC line.  This
+ * @brief	Generate byte array representing a fully formed VANC line.  This
  *              function will take in a klvanc_line_s, format the VANC entries to ensure there
- *              are no gaps or overlapping packets, and create a final pixel array which
- *              can be colorspace converted and output over SDI.
+ *              are no gaps or overlapping packets, and create a final byte array which
+ *              can be directly output over SDI in packed v210 format.
  *
+ * @param[in]	struct klvanc_context_s *ctx - Context.
  * @param[in]	struct klvanc_line_s *line - the VANC line to operate on
  * @param[out]	uint8_t *out_buf - a pointer to the buffer the function will output into.  The
  *              memory for the output buffer should be allocated by the caller (or in the case
  *              of working with Blackmagic cards, pass the buffer returned from
- *              vanc->GetBufferForVerticalBlankingLine().  Note that this buffer will determine
+ *              vanc->GetBufferForVerticalBlankingLine().  Note that this function will determine
  *              whether to do HD interleaving (inserting into the Y region only) or SD
  *              interleaving (using both Y and UV regions) based on the value provided via the
  *              line_pixel_width argument.

--- a/src/libklvanc/vanc-lines.h
+++ b/src/libklvanc/vanc-lines.h
@@ -134,6 +134,31 @@ int klvanc_line_insert(struct klvanc_context_s *ctx, struct klvanc_line_set_s *v
 int klvanc_generate_vanc_line(struct klvanc_context_s *ctx, struct klvanc_line_s *line,
 			      uint16_t **out_buf, int *out_len, int line_pixel_width);
 
+/**
+ * @brief	Generate pixel array representing a fully formed VANC line.  This
+ *              function will take in a klvanc_line_s, format the VANC entries to ensure there
+ *              are no gaps or overlapping packets, and create a final pixel array which
+ *              can be colorspace converted and output over SDI.
+ *
+ * @param[in]	struct klvanc_line_s *line - the VANC line to operate on
+ * @param[out]	uint8_t *out_buf - a pointer to the buffer the function will output into.  The
+ *              memory for the output buffer should be allocated by the caller (or in the case
+ *              of working with Blackmagic cards, pass the buffer returned from
+ *              vanc->GetBufferForVerticalBlankingLine().  Note that this buffer will determine
+ *              whether to do HD interleaving (inserting into the Y region only) or SD
+ *              interleaving (using both Y and UV regions) based on the value provided via the
+ *              line_pixel_width argument.
+ * @param[in]	int line_pixel_width - Size of the output buffer, measured in number of samples.
+ *              When working with Blackmagic cards, this value will typically be the line width
+ *              (e.g. 1920 for 1080i video), but there are special exceptions for certain 4K
+ *              cards so review the Blackmagic SDK documentation for details.  This function
+ *              will it insert VANC packets which exceed the line width specified.
+ * @return      0 - Success
+ * @return      -ENOMEM - insufficient memory to store the VANC packet
+ */
+int klvanc_generate_vanc_line_v210(struct klvanc_context_s *ctx, struct klvanc_line_s *line,
+				   uint8_t *out_buf, int line_pixel_width);
+
 #ifdef __cplusplus
 };
 #endif  


### PR DESCRIPTION
While the HD-SDI specification calls for VANC packets to be written
to the Y region (i.e. skipping U/V fields), with standard definition
SDI both the Y and UV are expected to be used.

Provide a pixel conversion routine, as well as creating a new variant
of the klvanc_generate_vanc_line() function which takes care of
the serialization automatically (based on the line width passed as
an argument).  This means the caller no longer has to take any
responsibility for the final colorspace conversion and can just
pass in the final VANC line buffer and the pixel width.