### PR TITLE
Afd bardata

### DIFF
--- a/src/core-did.c
+++ b/src/core-did.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <stdint.h>
 
+/* The content in this list comes from the SMPTE Registration Authority
+   https://smpte-ra.org/smpte-ancillary-data-smpte-st-291 */
 static struct did_s {
 	uint16_t did;
 	uint16_t sdid;
@@ -36,21 +38,104 @@ static struct did_s {
 	const char *desc;
 } dids[] = {
 	{ 0x00, 0x00,   "S291", "Undefined Data"},
+	{ 0x08, 0x08,   "S353", "MPEG recoding data, VANC space"},
+	{ 0x08, 0x0C,   "S353", "MPEG recoding data, HANC space"},
+	{ 0x40, 0x01,   "S305", "SDTI transport in active frame space"},
+	{ 0x40, 0x02,   "S348", "HD-SDTI transport in active frame space"},
+	{ 0x40, 0x04,   "S427", "Link Encryption Message 1"},
+	{ 0x40, 0x05,   "S427", "Link Encryption Message 2"},
+	{ 0x40, 0x06,   "S427", "Link Encryption Metadata"},
 	{ 0x40, 0xfe,   "KLABS","UINT64_T little endian frame counter"},
-	{ 0x41, 0x01,   "S352", "Payload Identification, VANC space"},
+	{ 0x41, 0x01,   "S352", "Payload Identification, HANC space"},
 	{ 0x41, 0x05,"S2016-3", "Active Format Description and Bar Data"},
 	{ 0x41, 0x06,"S2016-4", "Pan-Scan Data"},
-	{ 0x41, 0x07,  "S2010", "ANSI/SCTE 104 - Packet Type 2"},
+	{ 0x41, 0x07,  "S2010", "ANSI/SCTE 104 messages"},
 	{ 0x41, 0x08,  "S2031", "DVB/SCTE VBI data"},
+	{ 0x41, 0x09,  "S2056", "MPEG TS packets in VANC"},
+	{ 0x41, 0x0A,  "S2068", "Stereoscopic 3D Frame Compatible Packing and Signaling"},
+	{ 0x41, 0x0B,"S2064-2", "Lip Sync data as specified by ST 2064-1"},
+	{ 0x41, 0x0C,  "S2108", "Extended HDR/WCG for SDI"},
+	{ 0x43, 0x02,   "RDD8", "Subtitling Distribution packet (SDP)"},
+	{ 0x43, 0x03,   "RDD8", "Transport of ANC packet in an ANC Multipacket"},
+	{ 0x43, 0x04,"ARIB RT-B29", "Monitoring Metadata for ARIB Broadcasting chain"},
+	{ 0x43, 0x05,  "RDD18", "Acquisition Metadata Sets for Video Camera Parameters"},
+	{ 0x44, 0x04,  "RP214", "KLV Metadata transport in VANC space"},
+	{ 0x44, 0x14,  "RP214", "KLV Metadata transport in HANC space"},
+	{ 0x44, 0x44,  "RP223", "UMID and Program Identification Label Data"},
+	{ 0x45, 0x01,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x02,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x03,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x04,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x05,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x06,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x07,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x08,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x45, 0x09,"S2020-1", "Compressed Audio Metadata"},
+	{ 0x46, 0x01,  "S2051", "Two Frame Marker in HANC"},
+	{ 0x50, 0x01,   "RDD8", "WSS Data"},
+
+	/* Note: Not registered with SMPTE-RA (taken from ARIB STD-B37 Version 2.4-E1) */
+	{ 0x5F, 0xDC,"ARIB STD-B37", "ARIB Captioning - Mobile"},
+	{ 0x5F, 0xDD,"ARIB STD-B37", "ARIB Captioning - Analog"},
+	{ 0x5F, 0xDE,"ARIB STD-B37", "ARIB Captioning - SD"},
+	{ 0x5F, 0xDF,"ARIB STD-B37", "ARIB Captioning - HD"},
+
+	{ 0x51, 0x01,  "RP215", "Film Codes in VANC space"},
 	{ 0x60, 0x60, "S12M-2", "Ancillary Time Code"},
-	{ 0x61, 0x01,   "S334", "EIA 708B Data mapping into HDTV VBI, VANC space"},
-	{ 0x61, 0x02,   "S334", "EIA 608 Data mapping into HDTV VBI, VANC space"},
+	{ 0x60, 0x61, "S12M-3", "Time Code for High Frame Rate Signals"},
+	{ 0x60, 0x62,  "S2103", "Generic Time Label"},
+	{ 0x61, 0x01, "S334-1", "EIA 708B Data mapping into HDTV VBI, VANC space"},
+	{ 0x61, 0x02, "S334-1", "EIA 608 Data mapping into HDTV VBI, VANC space"},
+
+	/* Note: Not registered with SMPTE-RA (origin/validity unclear) */
 	{ 0x61, 0x03,   "S334", "World System Teletext Description Packet"},
 	{ 0x61, 0x04,   "S334", "Subtitling Data Essence (SDE)"},
 	{ 0x61, 0x05,   "S334", "ARIB Captioning - HD"},
 	{ 0x61, 0x06,   "S334", "ARIB Captioning - SD"},
 	{ 0x61, 0x07,   "S334", "ARIB Captioning - Analog"},
-	{ 0x80, 0x07,  "S2010", "ANSI/SCTE 104 - Packet Type 1 (deprecated)"},
+
+	{ 0x62, 0x01,  "RP207", "Program Description in VANC space"},
+	{ 0x62, 0x02, "S334-1", "Data broadcast (DTV) in VANC space"},
+	{ 0x62, 0x03,  "RP208", "VBI Data in VANC space"},
+	{ 0x64, 0x64,  "RP196", "Time Code in HANC space (Deprecated)"},
+	{ 0x64, 0x7F,  "RP196", "VITC in HANC space (Deprecated)"},
+};
+
+static struct did_s dids_t1[] = {
+	{ 0x00, 0x00,  "S291", "Undefined Data (Deprecated)"},
+	{ 0x80, 0x00,  "S291", "Packet marked for deletion"},
+	{ 0x84, 0x00,  "S291", "End packet deleted (Deprecated)"},
+	{ 0x88, 0x00,  "S291", "Start packet deleted (Deprecated)"},
+	{ 0xA0, 0x00,"S299-2", "Audio data in HANC space (3G) G8 Control"},
+	{ 0xA1, 0x00,"S299-2", "Audio data in HANC space (3G) G7 Control"},
+	{ 0xA2, 0x00,"S299-2", "Audio data in HANC space (3G) G6 Control"},
+	{ 0xA3, 0x00,"S299-2", "Audio data in HANC space (3G) G5 Control"},
+	{ 0xA4, 0x00,"S299-2", "Audio data in HANC space (3G) G8"},
+	{ 0xA5, 0x00,"S299-2", "Audio data in HANC space (3G) G7"},
+	{ 0xA6, 0x00,"S299-2", "Audio data in HANC space (3G) G6"},
+	{ 0xA7, 0x00,"S299-2", "Audio data in HANC space (3G) G5"},
+	{ 0xE0, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE1, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE2, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE3, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE4, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE5, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE6, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xE7, 0x00,"S299-1", "Audio data in HANC space (HDTV)"},
+	{ 0xEC, 0x00,  "S272", "Audio data in HANC space (SDTV)"},
+	{ 0xED, 0x00,  "S272", "Audio data in HANC space (SDTV)"},
+	{ 0xEE, 0x00,  "S272", "Audio data in HANC space (SDTV)"},
+	{ 0xEF, 0x00,  "S272", "Audio data in HANC space (SDTV)"},
+	{ 0xF0, 0x00,  "S315", "Camera Position (HANC or VANC space)"},
+	{ 0xF4, 0x00, "RP165", "Error Detection and Handling, HANC space"},
+	{ 0xF8, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xF9, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xFA, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xFB, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xFC, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xFD, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xFE, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
+	{ 0xFF, 0x00,  "S272", "Audio Data in HANC space (SDTV)"},
 };
 
 const char *klvanc_didLookupDescription(uint16_t did, uint16_t sdid)
@@ -58,6 +143,12 @@ const char *klvanc_didLookupDescription(uint16_t did, uint16_t sdid)
 	for (unsigned int i = 0; i < (sizeof(dids) / sizeof(struct did_s)); i++) {
 		if ((did == dids[i].did) && (sdid == dids[i].sdid))
 			return dids[i].desc;
+	}
+
+	/* No match for Type 2, check type 1 */
+	for (unsigned int i = 0; i < (sizeof(dids_t1) / sizeof(struct did_s)); i++) {
+		if (did == dids_t1[i].did)
+			return dids_t1[i].desc;
 	}
 
 	return "Undefined";
@@ -68,6 +159,12 @@ const char *klvanc_didLookupSpecification(uint16_t did, uint16_t sdid)
 	for (unsigned int i = 0; i < (sizeof(dids) / sizeof(struct did_s)); i++) {
 		if ((did == dids[i].did) && (sdid == dids[i].sdid))
 			return dids[i].spec;
+	}
+
+	/* No match for Type 2, check type 1 */
+	for (unsigned int i = 0; i < (sizeof(dids_t1) / sizeof(struct did_s)); i++) {
+		if (did == dids_t1[i].did)
+			return dids_t1[i].spec;
 	}
 
 	return "Undefined";

--- a/src/core-did.c
+++ b/src/core-did.c
@@ -38,7 +38,7 @@ static struct did_s {
 	{ 0x00, 0x00,   "S291", "Undefined Data"},
 	{ 0x40, 0xfe,   "KLABS","UINT64_T little endian frame counter"},
 	{ 0x41, 0x01,   "S352", "Payload Identification, VANC space"},
-	{ 0x41, 0x05,   "S352 / S2016-3", "AFD and Bar Data / Payload Identification, VANC space (Misconfigured upstream?)"},
+	{ 0x41, 0x05,"S2016-3", "Active Format Description and Bar Data"},
 	{ 0x41, 0x06,"S2016-4", "Pan-Scan Data"},
 	{ 0x41, 0x07,  "S2010", "ANSI/SCTE 104 - Packet Type 2"},
 	{ 0x41, 0x08,  "S2031", "DVB/SCTE VBI data"},

--- a/src/core-packet-afd.c
+++ b/src/core-packet-afd.c
@@ -136,6 +136,37 @@ int klvanc_dump_AFD(struct klvanc_context_s *ctx, void *p)
 		    pkt->barDataFlags,
 		    pkt->barDataValue[0],
 		    pkt->barDataValue[1]);
+	if (pkt->barDataFlags) {
+		PRINT_DEBUG(" Top bar flag = %x\n", (pkt->barDataFlags & 0x08) == 0x08);
+		PRINT_DEBUG(" Bottom bar flag = %x\n", (pkt->barDataFlags & 0x04) == 0x04);
+		PRINT_DEBUG(" Left bar flag = %x\n", (pkt->barDataFlags & 0x02) == 0x02);
+		PRINT_DEBUG(" Right bar flag = %x\n", (pkt->barDataFlags & 0x01) == 0x01);
+
+		/* Sec 6.1 - For the two pairs of top/bottom and left/right, either both have
+		   to be set or neither */
+		if ((pkt->barDataFlags & 0x0c) == 0x08 || (pkt->barDataFlags & 0x0c) == 0x04)
+			PRINT_DEBUG(" INVALID top/bottom pairing");
+
+		if ((pkt->barDataFlags & 0x03) == 0x02 || (pkt->barDataFlags & 0x03) == 0x01)
+			PRINT_DEBUG(" INVALID left right pairing");
+
+		/* Make sure there isn't some illegal combination of horizontal/vertical
+		   bits enabled (either top/bottom have to be enabled or left/right, but
+		   it can't be both) */
+		if ((pkt->barDataFlags & 0x0c) && (pkt->barDataFlags & 0x03))
+			PRINT_DEBUG(" INVALID both horizontal/vertical bar flags set");
+
+		/* Depending on which flags are set dictate which of the two values
+		   contains a given value */
+		if (pkt->barDataFlags & 0x08) {
+			PRINT_DEBUG(" Top bar = %d\n", pkt->barDataValue[0] & 0x3fff);
+			PRINT_DEBUG(" Bottom bar = %d\n", pkt->barDataValue[1] & 0x3fff);
+		}
+		if (pkt->barDataFlags & 0x02) {
+			PRINT_DEBUG(" Left bar = %d\n", pkt->barDataValue[0] & 0x3fff);
+			PRINT_DEBUG(" Right bar = %d\n", pkt->barDataValue[1] & 0x3fff);
+		}
+	}
 
 	return KLAPI_OK;
 }

--- a/src/core-packet-afd.c
+++ b/src/core-packet-afd.c
@@ -130,7 +130,7 @@ int klvanc_dump_AFD(struct klvanc_context_s *ctx, void *p)
 
 	struct klvanc_packet_afd_s *pkt = p;
 
-	PRINT_DEBUG("%s() AFD: %s Aspect Ratio: %s Flags: 0x%x Value1: 0x%x Value2: 0x%x\n", __func__,
+	PRINT_DEBUG("%s() AFD: %s Aspect Ratio: %s Flags: 0x%x Value1: 0x%04x Value2: 0x%04x\n", __func__,
 		    klvanc_afd_to_string(pkt->afd),
 		    klvanc_aspectRatio_to_string(pkt->aspectRatio),
 		    pkt->barDataFlags,

--- a/src/core-packets.c
+++ b/src/core-packets.c
@@ -44,20 +44,18 @@ static struct type_s
 {
 	unsigned short did, sdid;
 	enum klvanc_packet_type_e type;
-	const char *spec;
-	const char *description;
 	int (*parse)(struct klvanc_context_s *, struct klvanc_packet_header_s *, void **);
 	int (*dump)(struct klvanc_context_s *, void *);
 	void (*free)(void *);
 } types[] = {
-	{ 0x40, 0xfe, VANC_TYPE_KL_UINT64_COUNTER, "KLABS", "UINT64 LE Frame Counter", parse_KL_U64LE_COUNTER, klvanc_dump_KL_U64LE_COUNTER, free, },
-	{ 0x41, 0x05, VANC_TYPE_AFD, "SMPTE 2016-3 AFD", "Active Format Description", parse_AFD, klvanc_dump_AFD, free, },
-	{ 0x41, 0x07, VANC_TYPE_SCTE_104, "SMPTE Packet Type 2", "SCTE 104", parse_SCTE_104, klvanc_dump_SCTE_104, klvanc_free_SCTE_104, },
+	{ 0x40, 0xfe, VANC_TYPE_KL_UINT64_COUNTER, parse_KL_U64LE_COUNTER, klvanc_dump_KL_U64LE_COUNTER, free, },
+	{ 0x41, 0x05, VANC_TYPE_AFD, parse_AFD, klvanc_dump_AFD, free, },
+	{ 0x41, 0x07, VANC_TYPE_SCTE_104, parse_SCTE_104, klvanc_dump_SCTE_104, klvanc_free_SCTE_104, },
 #ifdef SCTE_104_PACKET_TYPE_1
-	{ 0x80, 0x07, VANC_TYPE_SCTE_104, "SMPTE Packet Type 1 (Deprecated)", "SCTE 104", parse_SCTE_104, klvanc_dump_SCTE_104, free, },
+	{ 0x80, 0x07, VANC_TYPE_SCTE_104, parse_SCTE_104, klvanc_dump_SCTE_104, free, },
 #endif
-	{ 0x61, 0x01, VANC_TYPE_EIA_708B, "SMPTE", "EIA_708B", parse_EIA_708B, klvanc_dump_EIA_708B, free, },
-	{ 0x61, 0x02, VANC_TYPE_EIA_608, "SMPTE", "EIA_608", parse_EIA_608, klvanc_dump_EIA_608, free, },
+	{ 0x61, 0x01, VANC_TYPE_EIA_708B, parse_EIA_708B, klvanc_dump_EIA_708B, free, },
+	{ 0x61, 0x02, VANC_TYPE_EIA_608, parse_EIA_608, klvanc_dump_EIA_608, free, },
 };
 
 static enum klvanc_packet_type_e lookupTypeByDID(unsigned short did, unsigned short sdid)
@@ -74,7 +72,8 @@ const char *klvanc_lookupDescriptionByType(enum klvanc_packet_type_e type)
 {
 	for (int i = 0; i < (sizeof(types) / sizeof(struct type_s)); i++) {
 		if (types[i].type == type)
-			return types[i].description;
+			return klvanc_didLookupDescription(types[i].did,
+							   types[i].sdid);
 	}
 
 	return "UNDEFINED";
@@ -84,7 +83,8 @@ const char *klvanc_lookupSpecificationByType(enum klvanc_packet_type_e type)
 {
 	for (int i = 0; i < (sizeof(types) / sizeof(struct type_s)); i++) {
 		if (types[i].type == type)
-			return types[i].spec;
+			return klvanc_didLookupSpecification(types[i].did,
+							     types[i].sdid);
 	}
 
 	return "UNDEFINED";


### PR DESCRIPTION
Patch series contains support for decoding AFD bar data, and some miscellaneous cleanups related to the list of known standards for registered DID/SDIDs.