### PR TITLE
708 50i fix

### DIFF
--- a/src/core-packet-eia_708b.c
+++ b/src/core-packet-eia_708b.c
@@ -77,8 +77,22 @@ void klvanc_destroy_eia708_cdp(struct klvanc_packet_eia_708b_s *pkt)
 	free(pkt);
 }
 
+static int gcd (int a, int b)
+{
+	int r;
+	while (b > 0) {
+		r = a % b;
+		a = b;
+		b = r;
+	}
+	return a;
+}
+
 int klvanc_set_framerate_EIA_708B(struct klvanc_packet_eia_708b_s *pkt, int num, int den)
 {
+	int gcd_val = gcd(num, den);
+	num /= gcd_val;
+	den /= gcd_val;
 	if (num == 1001 && den == 24000)
 		pkt->header.cdp_frame_rate = 0x01;
 	else if (num == 1 && den == 24)

--- a/src/libklvanc/vanc-afd.h
+++ b/src/libklvanc/vanc-afd.h
@@ -101,6 +101,14 @@ const char *klvanc_afd_to_string(enum klvanc_payload_afd_e afd);
 const char *klvanc_aspectRatio_to_string(enum klvanc_payload_aspect_ratio_e ar);
 
 /**
+ * @brief	Return a string representing the bar flags field
+ * @param[in]	enum klvanc_payload_afd_barflags flags - Value of flags field
+ * @return	Success - User facing printable string.
+ * @return	Error - NULL
+ */
+const char *klvanc_barFlags_to_string(enum klvanc_payload_afd_barflags flags);
+
+/**
  * @brief	TODO - Brief description goes here.
  * @param[in]	struct vanc_context_s *ctx, void *p - Brief description goes here.
  * @return	0 - Success


### PR DESCRIPTION
Provide a fix for issue where framerate is a non-reduced fraction, as well as a case where we added a new non-static function but didn't export it as part of the public API like we do for the other functions that convert enums to strings.