### PR TITLE
Make klvanc_cache_reset() take much less time

### DIFF
--- a/src/core-cache.c
+++ b/src/core-cache.c
@@ -108,6 +108,9 @@ void klvanc_cache_reset(struct klvanc_context_s *ctx)
 	for (int d = 0; d <= 0xff; d++) {
 		for (int s = 0; s <= 0xff; s++) {
 			struct klvanc_cache_s *e = klvanc_cache_lookup(ctx, d, s);
+
+			if (e->activeCount == 0)
+				continue;
 			e->activeCount = 0;
 
 			for (int l = 0; l < 2048; l++) {


### PR DESCRIPTION
Because of the core design of the cache, at initialization the
code allocates 255x255x2048 instances os klvanc_cache_line_s
(i.e. 133 million).  Iterating over these can take multiple seconds,
in particular with Clang which appears to not optimize the branch
prediction.

Add a quick check where if there were never any active entries found
on a DID/SDID, we don't bother iterating over the 2048 cache lines.

It's unusual to have more than a few different DID/SDIDs active
on any given SDI feed, so this reduces the cost to approx 1/65535.
On my laptop this results in the reset going from "waiting for
nearly ten seconds", to "virtually instantaneous".

For the record, the problem manifested as it taking nearly ten
seconds for klvanc_capture to exit from the time the user hit ctrl-c.