### PR TITLE
Oct2020 fixes

### DIFF
--- a/src/core-lines.c
+++ b/src/core-lines.c
@@ -107,8 +107,8 @@ int klvanc_line_insert(struct klvanc_context_s *ctx, struct klvanc_line_set_s *v
 
 static int vanc_ent_comp(const void *a, const void *b)
 {
-	const struct klvanc_entry_s *vala = (struct klvanc_entry_s *)a;
-	const struct klvanc_entry_s *valb = (struct klvanc_entry_s *)b;
+	const struct klvanc_entry_s *vala = *(struct klvanc_entry_s **) a;
+	const struct klvanc_entry_s *valb = *(struct klvanc_entry_s **) b;
 
 	if (vala->h_offset < valb->h_offset)
 		return -1;

--- a/src/core-packet-eia_608.c
+++ b/src/core-packet-eia_608.c
@@ -34,14 +34,13 @@ int klvanc_dump_EIA_608(struct klvanc_context_s *ctx, void *p)
 	if (ctx->verbose)
 		PRINT_DEBUG("%s() %p\n", __func__, (void *)pkt);
 
-	PRINT_DEBUG("%s() EIA608: %02x %02x %02x : marker-bits %02x cc_valid %d cc_type %d cc_data_1 %02x cc_data_2 %02x\n",
+	PRINT_DEBUG("%s() EIA608: %02x %02x %02x : field %d line_offset %d cc_data_1 %02x cc_data_2 %02x\n",
 		    __func__,
 		    pkt->payload[0],
 		    pkt->payload[1],
 		    pkt->payload[2],
-		    pkt->marker_bits,
-		    pkt->cc_valid,
-		    pkt->cc_type,
+		    pkt->field,
+		    pkt->line_offset,
 		    pkt->cc_data_1,
 		    pkt->cc_data_2);
 
@@ -68,9 +67,12 @@ int parse_EIA_608(struct klvanc_context_s *ctx, struct klvanc_packet_header_s *h
 	pkt->payload[1] = hdr->payload[1];
 	pkt->payload[2] = hdr->payload[2];
 
-	pkt->marker_bits = pkt->payload[0] >> 3;
-	pkt->cc_valid = (pkt->payload[0] >> 2) & 0x01;
-	pkt->cc_type = pkt->payload[0] & 0x03;
+        /* See SMPTE ST 334-1:2015 Annex B */
+	if (pkt->payload[0] & 0x80)
+		pkt->field = 0;
+	else
+		pkt->field = 1;
+	pkt->line_offset = pkt->payload[0] & 0x1f;
 	pkt->cc_data_1 = pkt->payload[1];
 	pkt->cc_data_2 = pkt->payload[2];
 

--- a/src/core-packet-eia_608.c
+++ b/src/core-packet-eia_608.c
@@ -82,3 +82,76 @@ int parse_EIA_608(struct klvanc_context_s *ctx, struct klvanc_packet_header_s *h
 	return KLAPI_OK;
 }
 
+int klvanc_create_EIA_608(struct klvanc_packet_eia_608_s **pkt)
+{
+	struct klvanc_packet_eia_608_s *p = calloc(1, sizeof(*p));
+	if (p == NULL)
+		return -ENOMEM;
+
+	*pkt = p;
+	return 0;
+}
+
+void klvanc_destroy_EIA_608(struct klvanc_packet_eia_608_s *pkt)
+{
+	free(pkt);
+}
+
+int klvanc_convert_EIA_608_to_packetBytes(struct klvanc_packet_eia_608_s *pkt, uint8_t **bytes, uint16_t *byteCount)
+{
+	if (!pkt || !bytes) {
+		return -1;
+	}
+
+	struct klbs_context_s *bs = klbs_alloc();
+	if (bs == NULL)
+		return -ENOMEM;
+
+	*bytes = malloc(255);
+	if (*bytes == NULL) {
+		klbs_free(bs);
+		return -ENOMEM;
+	}
+
+	/* Serialize the struct into a binary blob */
+	klbs_write_set_buffer(bs, *bytes, 255);
+
+	if (pkt->field == 0)
+		klbs_write_bits(bs, 1, 1);
+	else
+		klbs_write_bits(bs, 0, 1);
+
+	/* Reserved */
+	klbs_write_bits(bs, 0, 2);
+	klbs_write_bits(bs, pkt->line_offset, 5);
+
+	/* CC Payload */
+	klbs_write_bits(bs, pkt->cc_data_1, 8);
+	klbs_write_bits(bs, pkt->cc_data_2, 8);
+
+	klbs_write_buffer_complete(bs);
+
+	*byteCount = klbs_get_byte_count(bs);
+	klbs_free(bs);
+
+	return 0;
+}
+
+int klvanc_convert_EIA_608_to_words(struct klvanc_packet_eia_608_s *pkt, uint16_t **words, uint16_t *wordCount)
+{
+	uint8_t *buf;
+	uint16_t byteCount;
+	int ret;
+
+	ret = klvanc_convert_EIA_608_to_packetBytes(pkt, &buf, &byteCount);
+	if (ret != 0)
+		return ret;
+
+	/* Create the final array of VANC bytes (with correct DID/SDID,
+	   checksum, etc) */
+	klvanc_sdi_create_payload(0x02, 0x61, buf, byteCount, words, wordCount, 10);
+
+	free(buf);
+
+	return 0;
+}

--- a/src/libklvanc/vanc-eia_608.h
+++ b/src/libklvanc/vanc-eia_608.h
@@ -59,6 +59,46 @@ struct klvanc_packet_eia_608_s
  */
 int klvanc_dump_EIA_608(struct klvanc_context_s *ctx, void *p);
 
+/**
+ * @brief	Create an EIA-608 VANC packet
+ * @param[out]	struct klvanc_packet_eia_608_s **pkt - Pointer to newly created packet
+ * @return	0 - Success
+ * @return	< 0 - Error
+ */
+int klvanc_create_EIA_608(struct klvanc_packet_eia_608_s **pkt);
+
+/**
+ * @brief	Destroy an EIA-608 VANC packet
+ * @param[in]	struct klvanc_packet_eia_608_s *pkt - Packet to be destroyed
+ */
+void klvanc_destroy_EIA_608(struct klvanc_packet_eia_608_s *pkt);
+
+/**
+ * @brief	Convert type struct klvanc_packet_eia_608_s into a block of bytes which represents\n
+ *              an EIA-608 packet (without DID/SDID/DC/checksum)
+ *              On success, caller MUST free the resulting *bytes array.
+ * @param[in]	struct klvanc_packet_eia_608_s *pkt - An EIA-608 VANC entry, received from the EIA-608 parser
+ * @param[out]	uint8_t **bytes - An array of bytes representing the serialized EIA-608 packet
+ * @param[out]	uint16_t *byteCount - Number of bytes in the array.
+ * @return        0 - Success
+ * @return      < 0 - Error
+ * @return      -ENOMEM - Not enough memory to satisfy request
+ */
+int klvanc_convert_EIA_608_to_packetBytes(struct klvanc_packet_eia_608_s *pkt, uint8_t **bytes, uint16_t *byteCount);
+
+/**
+ * @brief	Convert type struct klvanc_packet_eia_608_s into a more traditional line of\n
+ *              vanc words, so that we may push out as VANC data.
+ *              On success, caller MUST free the resulting *words array.
+ * @param[in]	struct klvanc_packet_eia_608_s *pkt - A EIA-608 VANC entry
+ * @param[out]	uint16_t **words - An array of words representing a fully formed vanc line.
+ * @param[out]	uint16_t *wordCount - Number of words in the array.
+ * @return        0 - Success
+ * @return      < 0 - Error
+ * @return      -ENOMEM - Not enough memory to satisfy request
+ */
+int klvanc_convert_EIA_608_to_words(struct klvanc_packet_eia_608_s *pkt, uint16_t **words, uint16_t *wordCount);
+
 #ifdef __cplusplus
 };
 #endif  

--- a/src/libklvanc/vanc-eia_608.h
+++ b/src/libklvanc/vanc-eia_608.h
@@ -45,9 +45,8 @@ struct klvanc_packet_eia_608_s
 	unsigned char payload[3];
 
 	/* Parsed */
-	int marker_bits;
-	int cc_valid;
-	int cc_type;
+	int field;
+	int line_offset;
 	unsigned char cc_data_1;
 	unsigned char cc_data_2;
 };

--- a/tools/demo.c
+++ b/tools/demo.c
@@ -309,6 +309,37 @@ static int test_EIA_708B(struct klvanc_context_s *ctx)
 	return 0;
 }
 
+static unsigned char eia608_entry[] = {
+	0x00, 0x00, 0x03, 0xff, 0x03, 0xff, 0x01, 0x61, 0x01, 0x02, 0x02, 0x03,
+	0x02, 0x95, 0x01, 0x80, 0x01, 0x80, 0x01, 0xfb, 0x02, 0x00, 0x00, 0x40,
+	0x02, 0x00
+};
+static int test_EIA_608(struct klvanc_context_s *ctx)
+{
+
+	printf("\nParsing a new CEA-608 VANC packet......\n");
+	uint16_t *arr = malloc(sizeof(eia608_entry) / 2 * sizeof(uint16_t));
+	if (arr == NULL)
+		return -1;
+
+	for (int i = 0; i < (sizeof(eia608_entry) / 2); i++) {
+		arr[i] = eia608_entry[i * 2] << 8 | eia608_entry[i * 2 + 1];
+	}
+
+	printf("Original Input\n");
+	for (int i = 0; i < (sizeof(eia608_entry) / 2); i++) {
+		printf("%04x ", arr[i]);
+	}
+	printf("\n");
+
+	int ret = klvanc_packet_parse(ctx, 13, arr, sizeof(eia608_entry) / sizeof(unsigned short));
+	free(arr);
+
+	return ret;
+
+	return 0;
+}
+
 static int test_checksum()
 {
 	/* 3 words ADF, 31 words of message, 1 words checksum */
@@ -402,6 +433,10 @@ int demo_main(int argc, char *argv[])
 	ret = test_EIA_708B(ctx);
 	if (ret < 0)
 		fprintf(stderr, "EIA_708B failed to parse\n");
+
+	ret = test_EIA_608(ctx);
+	if (ret < 0)
+		fprintf(stderr, "EIA_608 failed to parse\n");
 
 	ret = test_scte_104(ctx);
 	if (ret < 0)


### PR DESCRIPTION
This pull includes a fix for generation of VANC lines that contain multiple packets, as well as improvements related to ST 334-1 CEA-608 packet parsing and generation.