### PR TITLE
Fix for properly padding chroma region of 10-bit VANC

### DIFF
--- a/src/core-pixels.c
+++ b/src/core-pixels.c
@@ -135,23 +135,23 @@ void klvanc_y10_to_v210(uint16_t *src, uint8_t *dst, int width)
 	size_t w;
 
 	for (w = 0; w < len; w++) {
-		put_le32(&dst, src[w * 6 + 0] << 10);
-		put_le32(&dst, src[w * 6 + 1] | (src[w * 6 + 2] << 20));
-		put_le32(&dst, src[w * 6 + 3] << 10);
-		put_le32(&dst, src[w * 6 + 4] | (src[w * 6 + 5] << 20));
+		put_le32(&dst, 0x200          | (src[w * 6 + 0] << 10) | (0x200 << 20));
+		put_le32(&dst, src[w * 6 + 1] | (0x200 << 10)          | (src[w * 6 + 2] << 20));
+		put_le32(&dst, 0x200          | (src[w * 6 + 3] << 10) | (0x200 << 20));
+		put_le32(&dst, src[w * 6 + 4] | (0x200 << 10)          | (src[w * 6 + 5] << 20));
 	}
 
 	/* Handle remaining 0-5 bytes if any */
 	if (width % 6 > 0)
-		put_le32(&dst, src[w * 6 + 0] << 10);
+		put_le32(&dst, 0x200          | (src[w * 6 + 0] << 10) | (0x200 << 20));
 	if (width % 6 > 2)
-		put_le32(&dst, src[w * 6 + 1] | (src[w * 6 + 2] << 20));
+		put_le32(&dst, src[w * 6 + 1] | (0x200 << 10)          | (src[w * 6 + 2] << 20));
 	else if (width % 6 > 1)
-		put_le32(&dst, src[w * 6 + 1]);
+		put_le32(&dst, src[w * 6 + 1] | (0x200 << 10)          | (0x040 << 20));
 	if (width % 6 > 3)
-		put_le32(&dst, src[w * 6 + 3] << 10);
+		put_le32(&dst, 0x200          | (src[w * 6 + 3] << 10) | (0x200 << 20));
 	if (width % 6 > 4)
-		put_le32(&dst, src[w * 6 + 4]);
+		put_le32(&dst, src[w * 6 + 4] | (0x200 << 10)          | (0x040 << 20));
 }
 
 void klvanc_uyvy_to_v210(uint16_t *src, uint8_t *dst, int width)


### PR DESCRIPTION
Our conversion from Y10 to V210 was inserting 0x000 into the
chroma portion of the V210 output (which would get clamped to
0x004 by the decklink hardware).  The proper behavior is to set
the unused chroma values to 0x200.

While the actual VANC data is being stored in the luma region and
the chroma is unused, some downstream tools apparently expect to
find 0x200 in the chroma region, and fail to parse if otherwise.
So adjust our creation of the V210 region to properly pad the
chroma region with 0x200.  This patch also ensures any leftover
values in the luma range are set to 0x040.