### PR TITLE
Add meson build definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,16 @@ regressions).
 To run the tests after compilation, run the following command:
 
         make test
+
+## Compilation with meson
+
+Meson can be used as an alternative to autotools:
+
+        meson build
+        ninja -C build
+
+The documentation will be built automatically if Doxygen is available
+
+## Running tests with meson
+
+        meson test -C build

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,20 @@
+project('libklvanc', 'c',
+  default_options : ['buildtype=debugoptimized'])
+
+subdir('src')
+subdir('tools')
+
+doxygen = find_program('doxygen', required : false)
+
+datadir = join_paths(get_option('datadir'), 'doc', 'libklvanc')
+doxyfile = files('doxygen/libklvanc.doxyconf')
+
+if doxygen.found()
+  html_target = custom_target('libklvanc-docs',
+                            build_by_default: false,
+                            input: doxyfile,
+                            output: 'html',
+                            command: [doxygen, '@INPUT@'],
+                            install: true,
+                            install_dir: datadir)
+endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,52 @@
+klvanc_sources = files(
+  'core.c',
+  'core-packet-eia_708b.c',
+  'core-packet-eia_608.c',
+  'core-packet-scte_104.c',
+  'core-packet-afd.c',
+  'core-packet-sdp.c',
+  'core-packet-smpte_12_2.c',
+  'core-packets.c',
+  'core-lines.c',
+  'core-did.c',
+  'core-pixels.c',
+  'core-checksum.c',
+  'smpte2038.c',
+  'core-cache.c',
+  'core-packet-kl_u64le_counter.c',
+)
+
+klvanc_headers = files(
+  'libklvanc/vanc.h',
+  'libklvanc/did.h',
+  'libklvanc/pixels.h',
+  'libklvanc/smpte2038.h',
+  'libklvanc/vanc-eia_708b.h',
+  'libklvanc/vanc-eia_608.h',
+  'libklvanc/vanc-scte_104.h',
+  'libklvanc/vanc-smpte_12_2.h',
+  'libklvanc/vanc-packets.h',
+  'libklvanc/vanc-lines.h',
+  'libklvanc/vanc-afd.h',
+  'libklvanc/vanc-sdp.h',
+  'libklvanc/vanc-checksum.h',
+  'libklvanc/klrestricted_code_path.h',
+  'libklvanc/cache.h',
+  'libklvanc/vanc-kl_u64le_counter.h',
+)
+
+install_headers(klvanc_headers, subdir : 'libklvanc')
+
+klvanc_incdirs = include_directories('.')
+
+thread_dep = dependency('threads')
+
+libklvanc = library('klvanc', klvanc_sources,
+  include_directories : klvanc_incdirs,
+  install : true,
+  dependencies: [thread_dep],
+)
+
+libklvanc_dep = declare_dependency(link_with : libklvanc,
+  include_directories : klvanc_incdirs,
+)

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,56 @@
+sources = files(
+  'klvanc_util.c',
+  'demo.c',
+  'parse.c',
+  'smpte2038.c',
+  'scte104.c',
+  'genscte104.c',
+  'gensmpte2038.c',
+  'eia708.c',
+  'smpte12_2.c',
+  'afd.c',
+  'udp.c',
+  'url.c',
+  'ts_packetizer.c',
+  'klringbuffer.c',
+  'pes_extractor.c',
+)
+
+thread_dep = dependency('threads')
+
+foreach exe_name: [
+  'klvanc_util',
+  'klvanc_parse',
+  'klvanc_smpte2038',
+  'klvanc_scte104',
+  'klvanc_genscte104',
+  'klvanc_gensmpte2038',
+  'klvanc_eia708',
+  'klvanc_smpte12_2',
+  'klvanc_afd',
+]
+  exe = executable(exe_name,
+    sources,
+    install: true,
+    install_tag: 'bin',
+    dependencies: [libklvanc_dep, thread_dep]
+  )
+  if exe_name in [
+    'klvanc_eia708',
+    'klvanc_genscte104',
+    'klvanc_scte104',
+    'klvanc_smpte12_2',
+    'klvanc_gensmpte2038',
+    'klvanc_afd']
+    test_name = 'test_' + exe_name
+    test(test_name, exe)
+  elif exe_name == 'klvanc_smpte2038'
+    test_name = 'test_' + exe_name
+    test(test_name, exe,
+      args : [
+        '-i ../samples/smpte2038-sample-pid-01e9.ts',
+        '-P 0x1e9'
+      ]
+    )
+  endif
+endforeach


### PR DESCRIPTION
Hi,

Please find attached a set of patches that adds support for building libklvanc with the Meson build system.

I understand that from a maintainer's point of view these kind of unsolicited "add support for a different build system" patches are not always welcome, not least because they might add additional maintenance burden, so apologies in advance for that.

It would be fantastic to have support for building libklvanc with Meson in upstream libklvanc, as it would facilitate builds of dependent projects via Meson's `subproject` support.

To try the meson build:

$ meson --prefix=/tmp/prefix builddir
$ ninja -C builddir
$ ninja -C builddir test
$ ninja -C builddir install

You can install a recent Meson version with pip3 if your system does not have a recent one. You can also run Meson straight from a git checkout, since it's just python code.

Commit message follows:

```
Add meson build definitions
    
The test suite has been ported, and the README updated.
```