### PR TITLE
Add mingw-w64 support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        builder: [autotools, meson]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install meson automake autoconf ninja-build
+
+      - name: Build & Test (autotools)
+        if: ${{ matrix.builder == 'autotools' }}
+        run: |
+          ./autogen.sh --build
+          ./configure
+          make
+          make test
+
+      - name: Build & Test (meson)
+        if: ${{ matrix.builder == 'meson' }}
+        run: |
+          meson setup build
+          ninja -C build
+          ninja -C build test
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            autotools
+            mingw-w64-x86_64-gcc
+
+      - shell: msys2 {0}
+        run: |
+          ./autogen.sh --build
+          ./configure
+          make
+          make test
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *.o
+*.pc
+*.exe
+*.dll
+.cache/
 .deps/
 .libs/
 Makefile.in
@@ -11,6 +15,7 @@ config.log
 config.status
 config.sub
 configure
+configure~
 depcomp
 install-sh
 libtool
@@ -20,3 +25,4 @@ missing
 libklvanc.la
 src/libklvanc_la-*.lo
 doxygen/html
+compile_commands.json

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,15 @@ AM_COND_IF(DEBUG,
     AC_DEFINE(DEBUG, 1, [Define to 0 if this is a release build]),
     AC_DEFINE(DEBUG, 0, [Define to 1 or higher if this is a debug build]))
 
+on_windows=no
+case "${host_os}" in
+  mingw*|windows*)
+    on_windows=yes
+    ;;
+esac
+
+AM_CONDITIONAL([WINDOWS], [test $on_windows = yes])
+
 AC_CONFIG_FILES([Makefile src/Makefile tools/Makefile])
 AC_OUTPUT
 

--- a/src/core-private.h
+++ b/src/core-private.h
@@ -25,7 +25,7 @@
 #define vanc_PRIVATE_H
 
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 /* We'll have a mutex and a list of items */
 #include <pthread.h>

--- a/src/libklvanc/vanc-lines.h
+++ b/src/libklvanc/vanc-lines.h
@@ -38,7 +38,7 @@
 
 #include <stdint.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/libklvanc/vanc-packets.h
+++ b/src/libklvanc/vanc-packets.h
@@ -30,7 +30,7 @@
 #define _VANC_PACKETS_H
 
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/libklvanc/vanc.h
+++ b/src/libklvanc/vanc.h
@@ -37,8 +37,7 @@
 
 #include <stdint.h>
 #include <stdarg.h>
-#include <sys/errno.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <libklvanc/klrestricted_code_path.h>
 
 #ifdef __cplusplus

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -66,11 +66,11 @@ noinst_HEADERS += url.h
 noinst_HEADERS += version.h
 noinst_HEADERS += platform.h
 
-test: klvanc_eia708 klvanc_genscte104 klvanc_scte104 klvanc_smpte12_2 klvanc_afd klvanc_smpte2038 klvanc_gensmpte2038
-	./klvanc_eia708
-	./klvanc_genscte104
-	./klvanc_scte104
-	./klvanc_smpte12_2
-	./klvanc_gensmpte2038
-	./klvanc_afd
-	./klvanc_smpte2038 -i ../samples/smpte2038-sample-pid-01e9.ts -P 0x1e9
+test: klvanc_eia708$(EXEEXT) klvanc_genscte104$(EXEEXT) klvanc_scte104$(EXEEXT) klvanc_smpte12_2$(EXEEXT) klvanc_afd$(EXEEXT) klvanc_smpte2038$(EXEEXT) klvanc_gensmpte2038$(EXEEXT)
+	./klvanc_eia708$(EXEEXT)
+	./klvanc_genscte104$(EXEEXT)
+	./klvanc_scte104$(EXEEXT)
+	./klvanc_smpte12_2$(EXEEXT)
+	./klvanc_gensmpte2038$(EXEEXT)
+	./klvanc_afd$(EXEEXT)
+	./klvanc_smpte2038$(EXEEXT) -i ../samples/smpte2038-sample-pid-01e9.ts -P 0x1e9

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -8,10 +8,14 @@ AM_CPPFLAGS = -DVERSION=\"$(VERSION)\" -DPROG="\"$(PACKAGE)\"" -D_FILE_OFFSET_BI
 
 AM_CFLAGS = -Wall -O3
 
+if WINDOWS
+LDADD = ../src/libklvanc.la -lpthread
+else
 LDADD = ../src/libklvanc.la -lpthread -ldl
+endif
 
 if DEBUG
-	CFLAGS += -g
+CFLAGS += -g
 endif
 
 SRC  = klvanc_util.c
@@ -29,6 +33,7 @@ SRC += url.c
 SRC += ts_packetizer.c
 SRC += klringbuffer.c
 SRC += pes_extractor.c
+SRC += platform.c
 
 bin_PROGRAMS  = klvanc_util
 bin_PROGRAMS += klvanc_parse
@@ -59,6 +64,7 @@ noinst_HEADERS += ts_packetizer.h
 noinst_HEADERS += udp.h
 noinst_HEADERS += url.h
 noinst_HEADERS += version.h
+noinst_HEADERS += platform.h
 
 test: klvanc_eia708 klvanc_genscte104 klvanc_scte104 klvanc_smpte12_2 klvanc_afd klvanc_smpte2038 klvanc_gensmpte2038
 	./klvanc_eia708

--- a/tools/klvanc_util.c
+++ b/tools/klvanc_util.c
@@ -23,6 +23,8 @@
 #include <string.h>
 #include <libgen.h>
 
+#include "platform.h"
+
 /* External tool hooks */
 extern int demo_main(int argc, char *argv[]);
 extern int parse_main(int argc, char *argv[]);
@@ -54,6 +56,9 @@ int main(int argc, char *argv[])
 		{ 0, 0 },
 	};
 	char *appname = basename(argv[0]);
+	char *extension = strcasestr_(appname, ".exe");
+	if (extension)
+		*extension = '\0';
 
 	int i = 0;
 	struct app_s *app = &apps[i++];

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -14,6 +14,7 @@ sources = files(
   'ts_packetizer.c',
   'klringbuffer.c',
   'pes_extractor.c',
+  'platform.c',
 )
 
 thread_dep = dependency('threads')

--- a/tools/platform.c
+++ b/tools/platform.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Jacob Lifshay <programmerjake@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/* utility functions that aren't available on all platforms, so we reimplement them here */
+
+#include <ctype.h>
+#include <string.h>
+
+#include "platform.h"
+
+char *strsep_(char **restrict stringp, const char *restrict delim)
+{
+	char *s = *stringp;
+	char *retval = s;
+	if (!retval)
+		return retval;
+	for (; *s; s++) {
+		for (const char *d = delim; *d; d++) {
+			if (*s == *d) {
+				*s++ = '\0';
+				*stringp = s;
+				return retval;
+			}
+		}
+	}
+	*stringp = NULL;
+	return retval;
+}
+
+int strncasecmp_(const char *s1, const char *s2, size_t n)
+{
+	for (size_t i = 0; i < n; i++) {
+		int c1 = tolower((unsigned char) s1[i]);
+		int c2 = tolower((unsigned char) s2[i]);
+		if (c1 < c2)
+			return -1;
+		if (c1 > c2)
+			return 1;
+		if (c1 == '\0')
+			break;
+	}
+	return 0;
+}
+
+char *strcasestr_(const char *haystack, const char *needle)
+{
+	size_t haystack_len = strlen(haystack);
+	size_t needle_len = strlen(needle);
+	for (; haystack_len >= needle_len; haystack++, haystack_len--) {
+		if (strncasecmp_(haystack, needle, needle_len) == 0)
+			return (char *) haystack;
+	}
+	return NULL;
+}

--- a/tools/platform.h
+++ b/tools/platform.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Jacob Lifshay <programmerjake@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* utility functions that aren't available on all platforms, so we reimplement them here */
+
+/** like `strsep` from glibc */
+char *strsep_(char **restrict stringp, const char *restrict delim);
+/** like `strncasecmp` from glibc */
+int strncasecmp_(const char *s1, const char *s2, size_t n);
+/** like `strcasestr` from glibc */
+char *strcasestr_(const char *haystack, const char *needle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tools/smpte2038.c
+++ b/tools/smpte2038.c
@@ -36,6 +36,7 @@
 #include "pes_extractor.h"
 #include "version.h"
 #include "hexdump.h"
+#include "platform.h"
 
 #define DEFAULT_FIFOSIZE 1048576
 #define DEFAULT_PID 0x80
@@ -268,16 +269,16 @@ static int _main(int argc, char *argv[])
 			} else
 				inputType = IT_UDP;
 			break;
-                case 'P':
-                        if ((sscanf(optarg, "0x%x", &ctx->pid) != 1) || (ctx->pid > 0x1fff))
+		case 'P':
+			if ((sscanf(optarg, "0x%x", &ctx->pid) != 1) || (ctx->pid > 0x1fff))
 				_usage(argv[0], 1);
-                        break;
+			break;
 		case 'v':
 			ctx->verbose++;
 			break;
 		case 't':
 			ctx->decode_types = optarg;
-			while( (dtype = strsep(&ctx->decode_types, ",")) != NULL ) {
+			while ((dtype = strsep_(&ctx->decode_types, ",")) != NULL) {
 				int found = 0;
 				if (strcmp("all", dtype) == 0) {
 					for (int j = 0; j < (sizeof(valid_decode_types) / sizeof(struct decode_types)); j++)
@@ -320,7 +321,7 @@ static int _main(int argc, char *argv[])
 	ctx->vanchdl->callbacks = &callbacks;
 
 	if (inputType == IT_UDP) {
-      	  int fs = DEFAULT_FIFOSIZE;
+		int fs = DEFAULT_FIFOSIZE;
 		if (ctx->i_url->has_fifosize)
 			fs = ctx->i_url->fifosize;
 

--- a/tools/udp.h
+++ b/tools/udp.h
@@ -27,9 +27,14 @@
 #include <sys/time.h>
 #include <pthread.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#define SOCKET int
+#endif
 #include <sys/time.h>
 
 #ifdef __cplusplus
@@ -37,9 +42,8 @@ extern "C" {
 #endif
 
 typedef void (*tsudp_receiver_callback)(void *userContext, unsigned char *buf, int byteCount);
-struct iso13818_udp_receiver_s
-{
-	int skt;
+struct iso13818_udp_receiver_s {
+	SOCKET skt;
 
 	struct sockaddr_in sin;
 	unsigned int ip_port;


### PR DESCRIPTION
I got it to cross compile from Debian 12 using Autotools.

I ended up deciding to just disable UDP support on Windows, since I don't need it and it's a large amount of porting work (I'm not familiar with how Windows does multicast or finding interfaces).

Since mingw-w64 doesn't have a `<regex.h>`, I replaced all the regexps with C code that should have equivalent/improved functionality.

I also added `.clang-format` with a style that matched what existed before relatively closely (I couldn't match the line break in between `else` and `if`) and formatted all the code.

Because the code was reformatted, you'll definitely want to review it commit-by-commit rather than just looking at the combined diff.

Please don't squash or rebase that commit unless you also update `.git-blame-ignore-revs`.

I added CI that runs on GitHub Actions, it tests building on ubuntu 22.04 and 24.04 with either meson or autotools as well as on windows in msys2 with autotools. It works on my fork on [Linux](https://github.com/programmerjake/libklvanc/actions/runs/15576199619) and [Windows](https://github.com/programmerjake/libklvanc/actions/runs/15576199609), but you seem to not have CI enabled on your repository, so it doesn't show up in this PR.